### PR TITLE
Fix nonce verification timing issue (closes #3)

### DIFF
--- a/cloudfront-cache-invalidator.php
+++ b/cloudfront-cache-invalidator.php
@@ -13,7 +13,7 @@
  * Plugin Name: CloudFront Cache Invalidator
  * Plugin URI: https://github.com/notglossy/CloudFront-Cache-Invalidator
  * Description: Automatically invalidates CloudFront cache when WordPress content is updated.
- * Version: 1.1.0
+ * Version: 1.2.0
  * Author: Not Glossy LLC
  * Author URI: https://github.com/notglossy
  * License: GPL3
@@ -26,7 +26,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 if ( ! defined( 'NOTGLOSSY_CLOUDFRONT_CACHE_INVALIDATOR_VERSION' ) ) {
-	define( 'NOTGLOSSY_CLOUDFRONT_CACHE_INVALIDATOR_VERSION', '1.1.0' );
+	define( 'NOTGLOSSY_CLOUDFRONT_CACHE_INVALIDATOR_VERSION', '1.2.0' );
 }
 
 // Include AWS SDK via Composer autoloader.


### PR DESCRIPTION
## Summary
Fixes #3 by implementing POST-Redirect-GET pattern for the manual invalidation form.

## Problem
The manual invalidation form's POST handling occurred AFTER the page was rendered inside `render_settings_page()`, causing:
- Page refresh re-triggering invalidation (no POST-Redirect-GET pattern)
- Nonce verification happening late in page lifecycle
- Not following WordPress best practices for form handling

## Solution
Implemented the WordPress-recommended `admin_post_` hook pattern with transient-based admin notices.

## Changes
- **Added `admin_post_cloudfront_invalidate_all` hook** - Handles form submission early in request lifecycle
- **Added `admin_notices` hook** - Displays success/error messages after redirect
- **Created `handle_manual_invalidation()` method** - Processes invalidation and stores result in transient
- **Created `display_invalidation_notices()` method** - Displays notices from transients
- **Updated manual invalidation form** - Now POSTs to `admin-post.php`
- **Removed inline POST handling** - Deleted problematic code from `render_settings_page()`
- **Version bump to 1.2.0**

## Security Improvements
- ✅ Nonce verification now occurs before any output
- ✅ Prevents form resubmission on page refresh
- ✅ User-specific transients prevent cross-user notice leakage
- ✅ Follows WordPress best practices for form handling
- ✅ Proper capability checks (`manage_options`)
- ✅ Safe redirects using `wp_safe_redirect()`

## Testing
- ✅ Code passes WordPress Coding Standards (WPCS)
- ✅ No PHPCS errors (only benign base64 warnings for encryption)
- ✅ Implements proper POST-Redirect-GET pattern
- ✅ Admin notices display correctly and are dismissible

## Files Changed
- `cloudfront-cache-invalidator.php` - Version update
- `includes/class-notglossy-cloudfront-cache-invalidator.php` - Main implementation