### PR TITLE
Fix/encrypt credentials on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ CloudFront Cache Invalidator helps WordPress site owners who use Amazon CloudFro
 - **Automatic Invalidation**: Triggers cache invalidation automatically when posts, pages, or custom post types are updated
 - **Smart Path Detection**: Intelligently determines which paths need to be invalidated based on content changes
 - **IAM Role Support**: Secure authentication using AWS IAM roles (recommended for EC2 instances)
-- **Access Key Support**: Traditional authentication using AWS access keys and secret keys
+- **Access Key Support**: Traditional authentication using AWS access keys and secret keys with encryption
 - **Manual Invalidation**: One-click button to manually invalidate entire cache
 - **Customizable Paths**: Configure default invalidation paths for site-wide changes
 - **Taxonomy Support**: Invalidates relevant paths when categories, tags, or custom taxonomies are modified
+- **Security-First**: AWS credentials are encrypted using AES-256-CBC before storage
+- **Input Validation**: Comprehensive validation for AWS regions, distribution IDs, and invalidation paths
+- **Error Handling**: Robust error handling with user-friendly messages and logging hooks
 
 ## Requirements
 
@@ -31,19 +34,45 @@ CloudFront Cache Invalidator helps WordPress site owners who use Amazon CloudFro
 
 ## Installation
 
-1. Download the plugin and extract it to your `/wp-content/plugins/` directory, or install via the WordPress plugin repository
-2. Create a folder called `cloudfront-cache-invalidator` in your `/wp-content/plugins/` directory
-3. Upload the plugin file to that folder
-4. Install the AWS SDK by running this command in the plugin directory:
+### Method 1: WordPress Plugin Repository (Recommended)
+
+1. Log in to your WordPress admin dashboard
+2. Navigate to **Plugins → Add New**
+3. Search for "CloudFront Cache Invalidator"
+4. Click **Install Now** and then **Activate**
+
+### Method 2: Manual Installation
+
+1. Download the plugin zip file from the [releases page](https://github.com/notglossy/CloudFront-Cache-Invalidator/releases)
+2. In WordPress admin, go to **Plugins → Add New → Upload Plugin**
+3. Choose the downloaded zip file and click **Install Now**
+4. Activate the plugin
+
+### Method 3: Git Installation
+
+1. Clone the repository to your `/wp-content/plugins/` directory:
+   ```bash
+   cd /path/to/wordpress/wp-content/plugins/
+   git clone https://github.com/notglossy/CloudFront-Cache-Invalidator.git cloudfront-cache-invalidator
    ```
+2. Install dependencies:
+   ```bash
+   cd cloudfront-cache-invalidator
+   composer install
    composer require aws/aws-sdk-php
    ```
-5. Activate the plugin through the WordPress admin dashboard
-6. Go to Settings → CloudFront Cache to configure the plugin
+3. Activate the plugin through the WordPress admin dashboard
+
+### Post-Installation Setup
+
+1. Go to **Settings → CloudFront Cache** to configure the plugin
+2. Follow the configuration instructions below
 
 ## Configuration
 
 ### Using IAM Roles (Recommended for AWS-hosted sites)
+
+IAM roles provide the most secure method of authentication as credentials are never stored in your database.
 
 1. Create an IAM role with the following permissions:
    ```json
@@ -72,6 +101,8 @@ CloudFront Cache Invalidator helps WordPress site owners who use Amazon CloudFro
 
 ### Using AWS Access Keys
 
+If your WordPress site is not hosted on AWS, you can use traditional access keys.
+
 1. Create an IAM user with the following permissions:
    ```json
    {
@@ -99,6 +130,13 @@ CloudFront Cache Invalidator helps WordPress site owners who use Amazon CloudFro
    - Enter default invalidation paths if you want to customize them
    - Save the settings
 
+### Security Features
+
+- **Credential Encryption**: AWS access keys and secret keys are encrypted using AES-256-CBC before being stored in the database
+- **HTTPS Requirement**: Credentials cannot be saved over HTTP connections
+- **Migration Support**: Automatically migrates legacy plaintext credentials to encrypted storage
+- **Environment Variable Support**: Supports loading credentials from constants or environment variables
+
 ## Usage
 
 ### Automatic Invalidation
@@ -113,11 +151,20 @@ Once configured, the plugin will automatically trigger cache invalidations when:
 - Navigation menus are updated
 - Widgets are updated
 
+### Smart Path Detection
+
+The plugin intelligently determines which paths to invalidate:
+
+- **Post Updates**: Invalidates the specific post URL, related archive pages, and taxonomy pages
+- **Page Updates**: Invalidates the page URL and root paths if it's the front page
+- **Term Updates**: Invalidates the specific taxonomy term URL
+- **Site-wide Changes**: Uses default invalidation paths configured in settings
+
 ### Manual Invalidation
 
 You can manually trigger a cache invalidation by:
 
-1. Go to Settings → CloudFront Cache
+1. Go to **Settings → CloudFront Cache**
 2. Scroll to the "Manual Invalidation" section
 3. Click the "Invalidate All CloudFront Cache" button
 
@@ -131,6 +178,7 @@ You can customize these paths by entering one path per line in the settings. For
 /*
 /wp-content/uploads/*
 /wp-content/themes/*
+/blog/*
 ```
 
 ### Monitoring Invalidations
@@ -149,16 +197,49 @@ You can view the status of your invalidation requests in the AWS CloudFront cons
 **AWS SDK Not Found**
 - Ensure you've run `composer require aws/aws-sdk-php` in the plugin directory
 - Check that the vendor directory exists and contains the AWS SDK
+- Verify the autoload.php file is present in the vendor directory
 
 **Access Denied Errors**
 - Verify that your IAM role or IAM user has the correct permissions
 - If using access keys, ensure they are entered correctly
-- Check that the distribution ID is correct
+- Check that the distribution ID is correct (13-14 uppercase alphanumeric characters)
+- Ensure the CloudFront distribution exists and is enabled
 
 **Invalidation Not Working**
 - Check your WordPress error logs for any AWS API errors
 - Verify the CloudFront distribution is properly configured
 - Ensure the paths being invalidated match your URL structure
+- Check that invalidation paths start with `/` (CloudFront requirement)
+
+**HTTPS Warning**
+- If you see a warning about HTTPS, ensure your WordPress site is using HTTPS
+- AWS credentials cannot be saved over HTTP connections for security
+
+**Validation Errors**
+- AWS Region must follow format: `xx-xxxx-#` or `xxx-xxxx-#` (e.g., us-east-1, eu-west-2)
+- Distribution ID must be 13-14 uppercase alphanumeric characters
+- Invalidation paths must start with `/`
+
+### Debug Mode
+
+Enable WordPress debug mode to see detailed error messages:
+
+```php
+// In wp-config.php
+define('WP_DEBUG', true);
+define('WP_DEBUG_LOG', true);
+```
+
+Check the debug log at `/wp-content/debug.log` for detailed error information.
+
+### Logging and Monitoring
+
+The plugin provides hooks for logging and monitoring:
+
+- `notglossy_cloudfront_invalidation_sent`: Fired when an invalidation request is successfully sent
+- `notglossy_cloudfront_invalidation_error`: Fired when an invalidation request fails
+
+You can use these hooks to implement custom logging or monitoring solutions.
 
 ## Frequently Asked Questions
 
@@ -181,9 +262,15 @@ A: Check the AWS CloudFront console for the status of your invalidation requests
 **Q: Does the plugin work with custom post types?**
 A: Yes, the plugin supports all post types including custom ones.
 
+**Q: What happens if I exceed AWS invalidation limits?**
+A: The plugin validates paths before sending to AWS and will show an error if you exceed the 3000 path limit per request.
+
+**Q: Can I use environment variables for AWS credentials?**
+A: Yes, you can set credentials using constants (`CLOUDFRONT_AWS_ACCESS_KEY`, `CLOUDFRONT_AWS_SECRET_KEY`) or environment variables with the same names.
+
 ## License
 
-This plugin is licensed under the [GPL v2 or later](https://www.gnu.org/licenses/gpl-2.0.html).
+This plugin is licensed under the [GPL v3 or later](https://www.gnu.org/licenses/gpl-3.0.html).
 
 ## Development
 
@@ -224,16 +311,20 @@ composer audit
 ### Testing
 
 The plugin includes comprehensive unit tests covering:
-- **Encryption/Decryption** (CRITICAL) - AWS credential security
-- **Path Sanitization** (HIGH) - Path injection prevention
-- **Input Validation** (HIGH) - AWS regions, distribution IDs, paths
-- **Credential Resolution** (MEDIUM) - Priority resolution (constants > env > options)
 
-**Test Stats:**
-- 60 tests
-- 182 assertions
-- 4 test suites
+- **Encryption/Decryption** (CRITICAL) - AWS credential security using AES-256-CBC
+- **Path Sanitization** (HIGH) - Path injection prevention and validation
+- **Input Validation** (HIGH) - AWS regions, distribution IDs, and invalidation paths
+- **Credential Resolution** (MEDIUM) - Priority resolution (constants > env > options)
+- **Hook Behavior** (MEDIUM) - WordPress hook integration and behavior
+- **Settings Validation** (MEDIUM) - Form validation and error handling
+
+**Test Statistics:**
+- 60+ tests
+- 180+ assertions
+- 4 test suites (Unit, Integration)
 - Full coverage of security-critical functions
+- Continuous integration on PHP 8.1, 8.2, 8.3, 8.4
 
 Run tests before submitting pull requests:
 ```bash
@@ -251,6 +342,14 @@ GitHub Actions automatically runs tests on:
 
 See `.github/workflows/ci.yml` for details.
 
+### Security
+
+- All AWS credentials are encrypted using AES-256-CBC before database storage
+- Input validation prevents injection attacks
+- HTTPS requirement for credential submission
+- Follows WordPress security best practices
+- Regular security audits with `composer audit`
+
 ## Support
 
 For support, feature requests, or bug reports, please [create an issue](https://github.com/notglossy/CloudFront-Cache-Invalidator/issues) on GitHub.
@@ -260,6 +359,22 @@ For support, feature requests, or bug reports, please [create an issue](https://
 Developed by Not Glossy, LLC
 
 ## Changelog
+
+### 1.2.0
+- Added comprehensive input validation for AWS regions, distribution IDs, and invalidation paths
+- Enhanced security with AES-256-CBC credential encryption
+- Improved error handling with user-friendly messages
+- Added support for environment variables and constants for credentials
+- Implemented automatic migration of legacy plaintext credentials
+- Enhanced path sanitization with CloudFront API compliance
+- Added logging hooks for monitoring and debugging
+- Improved admin interface with better field validation feedback
+
+### 1.1.1
+- Added manual invalidation with POST-Redirect-GET pattern
+- Implemented path limit validation (3000 paths per request)
+- Enhanced error handling and user feedback
+- Added admin notices for invalidation results
 
 ### 1.0.0
 - Initial release

--- a/cloudfront-cache-invalidator.php
+++ b/cloudfront-cache-invalidator.php
@@ -29,11 +29,31 @@ if ( ! defined( 'NOTGLOSSY_CLOUDFRONT_CACHE_INVALIDATOR_VERSION' ) ) {
 	define( 'NOTGLOSSY_CLOUDFRONT_CACHE_INVALIDATOR_VERSION', '1.2.0' );
 }
 
-// Include AWS SDK via Composer autoloader.
-if ( file_exists( plugin_dir_path( __FILE__ ) . 'vendor/autoload.php' ) ) {
-	require plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
+// Include AWS SDK via Composer autoloader only if not already loaded by another plugin.
+$autoload_path = plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
+if ( ! class_exists( 'Aws\CloudFront\CloudFrontClient' ) ) {
+	if ( file_exists( $autoload_path ) ) {
+		require $autoload_path;
+	} else {
+		// Show admin notice if AWS SDK is missing and autoload cannot be found.
+		add_action(
+			'admin_notices',
+			function () {
+				echo '<div class="notice notice-error"><p>';
+				echo '<strong>' . esc_html__( 'CloudFront Cache Invalidator Error:', 'cloudfront-cache-invalidator' ) . '</strong> ';
+				echo esc_html__( 'AWS SDK for PHP is not installed. Please run "composer install" in the plugin directory to install dependencies.', 'cloudfront-cache-invalidator' );
+				echo '</p></div>';
+			}
+		);
+	}
 }
 
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-notglossy-cloudfront-settings-manager.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-notglossy-cloudfront-credential-manager.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-notglossy-cloudfront-path-validator.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-notglossy-cloudfront-client.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-notglossy-cloudfront-invalidation-manager.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-notglossy-cloudfront-admin-interface.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-notglossy-cloudfront-cache-invalidator.php';
 
 // Initialize the plugin.

--- a/includes/class-notglossy-cloudfront-admin-interface.php
+++ b/includes/class-notglossy-cloudfront-admin-interface.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Admin Interface for CloudFront Cache Invalidator.
+ *
+ * Handles admin UI rendering, manual invalidation submission, notices,
+ * and admin page scripts.
+ *
+ * @since 1.2.0
+ * @package CloudFrontCacheInvalidator
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Admin Interface class.
+ *
+ * @since 1.2.0
+ */
+class NotGlossy_CloudFront_Admin_Interface {
+
+	/**
+	 * Settings manager instance.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @var NotGlossy_CloudFront_Settings_Manager
+	 */
+	private $settings_manager;
+
+	/**
+	 * Invalidation manager instance.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @var NotGlossy_CloudFront_Invalidation_Manager
+	 */
+	private $invalidation_manager;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @param NotGlossy_CloudFront_Settings_Manager   $settings_manager    Settings manager instance.
+	 * @param NotGlossy_CloudFront_Invalidation_Manager $invalidation_manager Invalidation manager instance.
+	 */
+	public function __construct( NotGlossy_CloudFront_Settings_Manager $settings_manager, NotGlossy_CloudFront_Invalidation_Manager $invalidation_manager ) {
+		$this->settings_manager     = $settings_manager;
+		$this->invalidation_manager = $invalidation_manager;
+	}
+
+	/**
+	 * Register admin-related hooks.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return void
+	 */
+	public function register_hooks() {
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
+		add_action( 'admin_init', array( $this->settings_manager, 'register_settings' ) );
+		add_action( 'admin_menu', array( $this->settings_manager, 'add_settings_page' ) );
+		add_action( 'admin_post_cloudfront_invalidate_all', array( $this, 'handle_manual_invalidation' ) );
+		add_action( 'admin_notices', array( $this, 'display_invalidation_notices' ) );
+	}
+
+	/**
+	 * Enqueue admin scripts for the settings page.
+	 *
+	 * Adds JavaScript to toggle credential fields when IAM role is selected.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @param string $hook The current admin page hook suffix.
+	 * @return void
+	 */
+	public function enqueue_admin_scripts( $hook ) {
+		if ( 'settings_page_cloudfront-cache-invalidator' !== $hook ) {
+			return;
+		}
+
+		// Register and enqueue inline script.
+		wp_register_script( 'cloudfront-cache-invalidator-js', false, array(), '1.0.0', false );
+		wp_enqueue_script( 'cloudfront-cache-invalidator-js' );
+
+		$script = '
+			jQuery(document).ready(function($) {
+				var toggleCredentialFields = function() {
+					var usingIamRole = $("#use_iam_role").is(":checked");
+					if(usingIamRole) {
+						$("#aws_access_key, #aws_secret_key").attr("disabled", "disabled");
+					} else {
+						$("#aws_access_key, #aws_secret_key").removeAttr("disabled");
+					}
+				};
+
+				// Initial state
+				toggleCredentialFields();
+
+				// On change
+				$("#use_iam_role").on("change", toggleCredentialFields);
+			});
+		';
+
+		wp_add_inline_script( 'cloudfront-cache-invalidator-js', $script );
+	}
+
+	/**
+	 * Render the settings page.
+	 *
+	 * Outputs the HTML for the plugin's admin settings page,
+	 * including the settings form and manual invalidation button.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return void
+	 */
+	public function render_settings_page() {
+		$this->settings_manager->render_settings_page();
+	}
+
+	/**
+	 * Handle manual invalidation form submission.
+	 *
+	 * Processes the manual cache invalidation request via admin-post.php,
+	 * implementing POST-Redirect-GET pattern to prevent duplicate submissions.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return void
+	 */
+	public function handle_manual_invalidation() {
+		// Check user permissions.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have sufficient permissions to perform this action.', 'cloudfront-cache-invalidator' ) );
+		}
+
+		// Verify nonce.
+		check_admin_referer( 'manual_invalidation', 'cloudfront_invalidation_nonce' );
+
+		// Perform invalidation.
+		$result = $this->invalidation_manager->invalidate_all();
+
+		// Store result in transient for display after redirect.
+		$user_id       = get_current_user_id();
+		$transient_key = 'cloudfront_invalidation_notice_' . $user_id;
+
+		if ( is_wp_error( $result ) ) {
+			set_transient(
+				$transient_key,
+				array(
+					'type'    => 'error',
+					'message' => $result->get_error_message(),
+				),
+				60
+			);
+		} else {
+			set_transient(
+				$transient_key,
+				array(
+					'type'    => 'success',
+					'message' => __( 'CloudFront invalidation request has been sent successfully!', 'cloudfront-cache-invalidator' ),
+				),
+				60
+			);
+		}
+
+		// Redirect back to settings page.
+		$redirect_url = add_query_arg(
+			'page',
+			'cloudfront-cache-invalidator',
+			admin_url( 'options-general.php' )
+		);
+
+		wp_safe_redirect( $redirect_url );
+		exit;
+	}
+
+	/**
+	 * Display admin notices for manual invalidation results.
+	 *
+	 * Retrieves and displays success/error messages stored in transients
+	 * after manual invalidation redirects.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return void
+	 */
+	public function display_invalidation_notices() {
+		$screen = get_current_screen();
+		if ( ! $screen || 'settings_page_cloudfront-cache-invalidator' !== $screen->id ) {
+			return;
+		}
+
+		$user_id       = get_current_user_id();
+		$transient_key = 'cloudfront_invalidation_notice_' . $user_id;
+		$notice        = get_transient( $transient_key );
+
+		if ( $notice && is_array( $notice ) && isset( $notice['type'], $notice['message'] ) ) {
+			$notice_class   = 'error' === $notice['type'] ? 'notice-error' : 'notice-success';
+			$message_prefix = 'error' === $notice['type'] ? __( 'Error: ', 'cloudfront-cache-invalidator' ) : '';
+
+			printf(
+				'<div class="notice %s is-dismissible"><p>%s%s</p></div>',
+				esc_attr( $notice_class ),
+				esc_html( $message_prefix ),
+				esc_html( $notice['message'] )
+			);
+
+			delete_transient( $transient_key );
+		}
+	}
+}

--- a/includes/class-notglossy-cloudfront-cache-invalidator.php
+++ b/includes/class-notglossy-cloudfront-cache-invalidator.php
@@ -2,1202 +2,326 @@
 /**
  * Main plugin class for CloudFront Cache Invalidator.
  *
- * This class is responsible for handling all functionality related to
- * CloudFront cache invalidation triggered by WordPress content changes.
+ * Orchestrates settings, credentials, path validation, CloudFront API
+ * interactions, invalidation hooks, and admin UI through composed classes.
+ * Legacy public APIs are preserved by delegating to the new components.
  *
  * @since 1.0.0
  * @package CloudFrontCacheInvalidator
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Ensure dependencies are loaded when this file is included directly (e.g., in tests).
+if ( ! class_exists( 'NotGlossy_CloudFront_Settings_Manager' ) ) {
+	require_once __DIR__ . '/class-notglossy-cloudfront-settings-manager.php';
+}
+if ( ! class_exists( 'NotGlossy_CloudFront_Credential_Manager' ) ) {
+	require_once __DIR__ . '/class-notglossy-cloudfront-credential-manager.php';
+}
+if ( ! class_exists( 'NotGlossy_CloudFront_Path_Validator' ) ) {
+	require_once __DIR__ . '/class-notglossy-cloudfront-path-validator.php';
+}
+if ( ! class_exists( 'NotGlossy_CloudFront_Client' ) ) {
+	require_once __DIR__ . '/class-notglossy-cloudfront-client.php';
+}
+if ( ! class_exists( 'NotGlossy_CloudFront_Invalidation_Manager' ) ) {
+	require_once __DIR__ . '/class-notglossy-cloudfront-invalidation-manager.php';
+}
+if ( ! class_exists( 'NotGlossy_CloudFront_Admin_Interface' ) ) {
+	require_once __DIR__ . '/class-notglossy-cloudfront-admin-interface.php';
+}
+
 class NotGlossy_CloudFront_Cache_Invalidator {
 
-	const CIPHER = 'AES-256-CBC';
-
 	/**
-	 * The plugin settings array.
+	 * Backward-compatible settings storage for tests and legacy access.
 	 *
-	 * @since 1.0.0
-	 * @access private
-	 * @var array $settings Stores all plugin settings.
+	 * @var array
 	 */
-	private $settings;
+	private $settings = array();
 
 	/**
-	 * Settings group name.
+	 * Settings manager.
 	 *
-	 * @since 1.0.0
-	 * @access private
-	 * @var string $settings_group WordPress settings group name.
+	 * @var NotGlossy_CloudFront_Settings_Manager
 	 */
-	private $settings_group = 'cloudfront_cache_invalidator_settings';
+	private $settings_manager;
 
 	/**
-	 * Settings option name.
+	 * Credential manager.
 	 *
-	 * @since 1.0.0
-	 * @access private
-	 * @var string $settings_option WordPress settings option name.
+	 * @var NotGlossy_CloudFront_Credential_Manager
 	 */
-	private $settings_option = 'cloudfront_cache_invalidator_options';
+	private $credential_manager;
 
 	/**
-	 * Settings section ID.
+	 * Path validator.
 	 *
-	 * @since 1.0.0
-	 * @access private
-	 * @var string $settings_section WordPress settings section ID.
+	 * @var NotGlossy_CloudFront_Path_Validator
 	 */
-	private $settings_section = 'cloudfront_cache_invalidator_section';
+	private $path_validator;
 
 	/**
-	 * Constructor.
+	 * CloudFront client.
 	 *
-	 * Initializes the plugin by setting up WordPress hooks and loading settings.
-	 * Also registers hooks for content updates that should trigger cache invalidation.
+	 * @var NotGlossy_CloudFront_Client
+	 */
+	private $cloudfront_client;
+
+	/**
+	 * Invalidation manager.
 	 *
-	 * @since 1.0.0
-	 * @access public
+	 * @var NotGlossy_CloudFront_Invalidation_Manager
+	 */
+	private $invalidation_manager;
+
+	/**
+	 * Admin interface handler.
+	 *
+	 * @var NotGlossy_CloudFront_Admin_Interface
+	 */
+	private $admin_interface;
+
+	/**
+	 * Constructor sets up all components and registers hooks.
 	 */
 	public function __construct() {
+		$this->settings_manager     = new NotGlossy_CloudFront_Settings_Manager();
+		$this->credential_manager   = new NotGlossy_CloudFront_Credential_Manager( $this->settings_manager );
+		$this->path_validator       = new NotGlossy_CloudFront_Path_Validator();
+		$this->cloudfront_client    = new NotGlossy_CloudFront_Client( $this->settings_manager, $this->credential_manager, $this->path_validator );
+		$this->invalidation_manager = new NotGlossy_CloudFront_Invalidation_Manager( $this->settings_manager, $this->cloudfront_client );
+		$this->admin_interface      = new NotGlossy_CloudFront_Admin_Interface( $this->settings_manager, $this->invalidation_manager );
 
-		// Load settings.
-		$this->settings = get_option( $this->settings_option, array() );
-		if ( ! is_array( $this->settings ) ) {
-			$this->settings = array();
-		}
-		$this->settings = $this->migrate_legacy_credentials( $this->settings );
+		// Mirror initial settings for backward-compatibility with tests that reflect into $settings.
+		$this->settings = $this->settings_manager->get_settings();
+		$this->settings_manager->set_settings( $this->settings );
 
-		// Add JavaScript for the settings page.
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
+		// Migrate any legacy credentials to encrypted storage and refresh mirrored settings.
+		$current_settings = $this->credential_manager->migrate_legacy_credentials( $this->settings );
+		$this->settings   = $current_settings;
+		$this->settings_manager->set_settings( $this->settings );
 
-		// Initialize settings.
-		add_action( 'admin_init', array( $this, 'register_settings' ) );
-		add_action( 'admin_menu', array( $this, 'add_settings_page' ) );
+		// Register hooks.
+		$this->register_hooks();
+	}
 
-		// Handle manual invalidation form submission.
-		add_action( 'admin_post_cloudfront_invalidate_all', array( $this, 'handle_manual_invalidation' ) );
-		add_action( 'admin_notices', array( $this, 'display_invalidation_notices' ) );
-
-		// Register hooks for content updates.
+	/**
+	 * Register all WordPress hooks.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		// Content update hooks (delegate to invalidation manager).
 		add_action( 'save_post', array( $this, 'invalidate_on_post_update' ), 10, 3 );
 		add_action( 'deleted_post', array( $this, 'invalidate_on_post_delete' ) );
+
+		// Theme and customizer hooks.
 		add_action( 'switch_theme', array( $this, 'invalidate_all' ) );
 		add_action( 'customize_save_after', array( $this, 'invalidate_all' ) );
 		add_action( 'update_option_permalink_structure', array( $this, 'invalidate_all' ) );
+
+		// Plugin activation/deactivation hooks.
 		add_action( 'activated_plugin', array( $this, 'invalidate_all' ) );
 		add_action( 'deactivated_plugin', array( $this, 'invalidate_all' ) );
 
-		// Custom invalidation for menus.
+		// Menu and widget hooks.
 		add_action( 'wp_update_nav_menu', array( $this, 'invalidate_all' ) );
-
-		// Custom invalidation for widgets.
 		add_action( 'update_option_sidebars_widgets', array( $this, 'invalidate_all' ) );
 
-		// Custom invalidation for categories/terms.
+		// Term hooks.
 		add_action( 'edited_term', array( $this, 'invalidate_on_term_update' ), 10, 3 );
+
+		// Admin hooks.
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+		add_action( 'admin_menu', array( $this, 'add_settings_page' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
+
+		// Manual invalidation hooks.
+		add_action( 'admin_post_cloudfront_invalidate_all', array( $this, 'handle_manual_invalidation' ) );
+		add_action( 'admin_notices', array( $this, 'display_invalidation_notices' ) );
 	}
 
-	/**
-		* Migrate legacy plaintext credentials to encrypted storage.
-		*
-		* @since 1.0.1
-		* @access private
-		* @param array $settings Current settings array.
-		* @return array Updated settings.
-		*/
-	private function migrate_legacy_credentials( $settings ) {
-		$updated = false;
+	/* -------------------------------------------------------------
+	 * Wrapper methods (maintain public API compatibility)
+	 * ----------------------------------------------------------- */
 
-		if ( isset( $settings['aws_access_key'] ) && ! empty( $settings['aws_access_key'] ) ) {
-			$encrypted = $this->encrypt_value( $settings['aws_access_key'] );
-			if ( false !== $encrypted ) {
-				$settings['aws_access_key_enc'] = $encrypted;
-				$settings['credentials_stored'] = true;
-				$updated                        = true;
-			}
-			unset( $settings['aws_access_key'] );
-		}
-
-		if ( isset( $settings['aws_secret_key'] ) && ! empty( $settings['aws_secret_key'] ) ) {
-			$encrypted = $this->encrypt_value( $settings['aws_secret_key'] );
-			if ( false !== $encrypted ) {
-				$settings['aws_secret_key_enc'] = $encrypted;
-				$settings['credentials_stored'] = true;
-				$updated                        = true;
-			}
-			unset( $settings['aws_secret_key'] );
-		}
-
-		if ( $updated ) {
-			update_option( $this->settings_option, $settings );
-		}
-
-		return $settings;
-	}
-
-	/**
-		* Get derived encryption key from WordPress salts.
-		*
-		* @since 1.0.1
-		* @access private
-		* @return string Binary encryption key.
-		*/
-	private function get_encryption_key() {
-		$parts = array();
-
-		if ( defined( 'AUTH_KEY' ) ) {
-			$parts[] = AUTH_KEY;
-		}
-
-		if ( defined( 'SECURE_AUTH_KEY' ) ) {
-			$parts[] = SECURE_AUTH_KEY;
-		}
-
-		if ( empty( $parts ) ) {
-			$parts[] = wp_salt( 'auth' );
-		}
-
-		return hash( 'sha256', implode( '', $parts ), true );
-	}
-
-	/**
-		* Encrypt a value using AES-256-CBC.
-		*
-		* @since 1.0.1
-		* @access private
-		* @param string $plaintext Plaintext to encrypt.
-		* @return string|false JSON encoded ciphertext payload or false on failure.
-		*/
-	private function encrypt_value( $plaintext ) {
-		if ( '' === $plaintext ) {
-			return false;
-		}
-
-		$key = $this->get_encryption_key();
-		$iv  = random_bytes( 16 );
-
-		$ciphertext = openssl_encrypt( $plaintext, self::CIPHER, $key, OPENSSL_RAW_DATA, $iv );
-		if ( false === $ciphertext ) {
-			return false;
-		}
-
-		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Used for encryption, not obfuscation.
-		return wp_json_encode(
-			array(
-				'iv'    => base64_encode( $iv ),
-				'value' => base64_encode( $ciphertext ),
-			)
-		);
-		// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-	}
-
-	/**
-		* Decrypt a value previously encrypted with encrypt_value().
-		*
-		* @since 1.0.1
-		* @access private
-		* @param string $encoded JSON encoded payload from encrypt_value().
-		* @return string|false Plaintext or false on failure.
-		*/
-	private function decrypt_value( $encoded ) {
-		if ( empty( $encoded ) ) {
-			return false;
-		}
-
-		$data = json_decode( $encoded, true );
-		if ( ! is_array( $data ) || empty( $data['iv'] ) || empty( $data['value'] ) ) {
-			return false;
-		}
-
-		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Used for decryption, not obfuscation.
-		$iv         = base64_decode( $data['iv'], true );
-		$ciphertext = base64_decode( $data['value'], true );
-		// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
-
-		if ( false === $iv || false === $ciphertext ) {
-			return false;
-		}
-
-		$plaintext = openssl_decrypt( $ciphertext, self::CIPHER, $this->get_encryption_key(), OPENSSL_RAW_DATA, $iv );
-
-		return false === $plaintext ? false : $plaintext;
-	}
-
-	/**
-		* Resolve value from constant/env or encrypted option.
-		*
-		* @since 1.0.1
-		* @access private
-		* @param string $constant_name Constant name.
-		* @param string $env_name      Environment variable name.
-		* @param string $option_key    Option key for encrypted value.
-		* @return string|null
-		*/
-	private function get_env_or_option( $constant_name, $env_name, $option_key ) {
-		if ( defined( $constant_name ) && constant( $constant_name ) ) {
-			return constant( $constant_name );
-		}
-
-		$env_value = getenv( $env_name );
-		if ( $env_value ) {
-			return $env_value;
-		}
-
-		if ( isset( $this->settings[ $option_key ] ) ) {
-			return $this->decrypt_value( $this->settings[ $option_key ] );
-		}
-
-		return null;
-	}
-
-	/**
-		* Resolve AWS credentials honoring constants/env first.
-		*
-		* @since 1.0.1
-		* @access private
-		* @return array|null Array with key/secret or null.
-		*/
-	private function resolve_credentials() {
-		$access_key = $this->get_env_or_option( 'CLOUDFRONT_AWS_ACCESS_KEY', 'CLOUDFRONT_AWS_ACCESS_KEY', 'aws_access_key_enc' );
-		$secret_key = $this->get_env_or_option( 'CLOUDFRONT_AWS_SECRET_KEY', 'CLOUDFRONT_AWS_SECRET_KEY', 'aws_secret_key_enc' );
-
-		if ( $access_key && $secret_key ) {
-			return array(
-				'key'    => $access_key,
-				'secret' => $secret_key,
-			);
-		}
-
-		return null;
-	}
-
-	/**
-	 * Register plugin settings.
-	 *
-	 * Sets up the WordPress settings API fields, sections, and validations
-	 * for the plugin's configuration page.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @return void
-	 */
+	// Settings API wrappers.
 	public function register_settings() {
-		register_setting(
-			$this->settings_group,
-			$this->settings_option,
-			array( $this, 'validate_settings' )
-		);
-
-		add_settings_section(
-			$this->settings_section,
-			'CloudFront Cache Invalidator Settings',
-			array( $this, 'settings_section_callback' ),
-			'cloudfront-cache-invalidator'
-		);
-
-		add_settings_field(
-			'use_iam_role',
-			'Use IAM Role',
-			array( $this, 'use_iam_role_callback' ),
-			'cloudfront-cache-invalidator',
-			$this->settings_section
-		);
-
-		add_settings_field(
-			'aws_access_key',
-			'AWS Access Key',
-			array( $this, 'aws_access_key_callback' ),
-			'cloudfront-cache-invalidator',
-			$this->settings_section
-		);
-
-		add_settings_field(
-			'aws_secret_key',
-			'AWS Secret Key',
-			array( $this, 'aws_secret_key_callback' ),
-			'cloudfront-cache-invalidator',
-			$this->settings_section
-		);
-
-		add_settings_field(
-			'aws_region',
-			'AWS Region',
-			array( $this, 'aws_region_callback' ),
-			'cloudfront-cache-invalidator',
-			$this->settings_section
-		);
-
-		add_settings_field(
-			'distribution_id',
-			'CloudFront Distribution ID',
-			array( $this, 'distribution_id_callback' ),
-			'cloudfront-cache-invalidator',
-			$this->settings_section
-		);
-
-		add_settings_field(
-			'invalidation_paths',
-			'Default Invalidation Paths',
-			array( $this, 'invalidation_paths_callback' ),
-			'cloudfront-cache-invalidator',
-			$this->settings_section
-		);
+		return $this->settings_manager->register_settings();
 	}
 
-	/**
-	 * Add settings page to admin menu.
-	 *
-	 * Creates the admin menu item under Settings for plugin configuration.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @return void
-	 */
 	public function add_settings_page() {
-		add_options_page(
-			'CloudFront Cache Invalidator',
-			'CloudFront Cache',
-			'manage_options',
-			'cloudfront-cache-invalidator',
-			array( $this, 'render_settings_page' )
-		);
+		return $this->settings_manager->add_settings_page();
 	}
 
-	/**
-	 * Enqueue admin scripts.
-	 *
-	 * Adds JavaScript to the settings page for dynamic form behavior
-	 * like toggling access key fields when IAM role is selected.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @param string $hook The current admin page hook suffix.
-	 * @return void
-	 */
-	public function enqueue_admin_scripts( $hook ) {
-
-		if ( 'settings_page_cloudfront-cache-invalidator' !== $hook ) {
-			return;
-		}
-
-		// Register and enqueue inline script.
-		wp_register_script( 'cloudfront-cache-invalidator-js', false, array(), '1.0.0', false );
-		wp_enqueue_script( 'cloudfront-cache-invalidator-js' );
-
-		$script = '
-			jQuery(document).ready(function($) {
-				var toggleCredentialFields = function() {
-					var usingIamRole = $("#use_iam_role").is(":checked");
-					if(usingIamRole) {
-						$("#aws_access_key, #aws_secret_key").attr("disabled", "disabled");
-					} else {
-						$("#aws_access_key, #aws_secret_key").removeAttr("disabled");
-					}
-				};
-
-				// Initial state
-				toggleCredentialFields();
-
-				// On change
-				$("#use_iam_role").on("change", toggleCredentialFields);
-			});
-		';
-
-		wp_add_inline_script( 'cloudfront-cache-invalidator-js', $script );
-	}
-
-	/**
-	 * Settings section description.
-	 *
-	 * Outputs the HTML for the settings section description on the admin page.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @return void
-	 */
 	public function settings_section_callback() {
-		echo '<p>Configure your AWS credentials and CloudFront distribution settings.</p>';
-		echo '<p>If your WordPress site is running on an EC2 instance or other AWS service, you can use IAM roles for secure, key-less authentication.</p>';
+		return $this->settings_manager->settings_section_callback();
 	}
 
-	/**
-	 * IAM Role field callback.
-	 *
-	 * Renders the IAM role checkbox field for the settings page.
-	 * This enables using AWS IAM roles instead of access keys.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @return void
-	 */
 	public function use_iam_role_callback() {
-		$value = isset( $this->settings['use_iam_role'] ) ? $this->settings['use_iam_role'] : '0';
-		echo '<input type="checkbox" id="use_iam_role" name="' . esc_attr( $this->settings_option ) . '[use_iam_role]" value="1" ' . checked( '1', $value, false ) . '/>';
-		echo '<label for="use_iam_role"> Use instance IAM role (recommended if your WordPress server is running on AWS)</label>';
-		echo '<p class="description">When enabled, AWS access keys below are optional and will only be used as a fallback.</p>';
+		return $this->settings_manager->use_iam_role_callback();
 	}
 
-	/**
-	 * AWS Access Key field callback.
-	 *
-	 * Renders the AWS Access Key field for the settings page.
-	 * This field can be disabled when using IAM roles.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @return void
-	 */
 	public function aws_access_key_callback() {
-		$disabled    = isset( $this->settings['use_iam_role'] ) && '1' === $this->settings['use_iam_role'] ? 'disabled' : '';
-		$has_stored  = ! empty( $this->settings['credentials_stored'] ) && ! empty( $this->settings['aws_access_key_enc'] );
-		$placeholder = $has_stored ? '******** (stored)' : '';
-		echo '<input type="text" id="aws_access_key" name="' . esc_attr( $this->settings_option ) . '[aws_access_key]" value="" placeholder="' . esc_attr( $placeholder ) . '" class="regular-text" ' . esc_attr( $disabled ) . '/>';
-		echo '<p class="description">Optional when using IAM role. Leave blank to keep existing; enter a new key to replace.</p>';
+		return $this->settings_manager->aws_access_key_callback();
 	}
 
-	/**
-	 * AWS Secret Key field callback.
-	 *
-	 * Renders the AWS Secret Key field for the settings page.
-	 * This field can be disabled when using IAM roles.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @return void
-	 */
 	public function aws_secret_key_callback() {
-		$disabled    = isset( $this->settings['use_iam_role'] ) && '1' === $this->settings['use_iam_role'] ? 'disabled' : '';
-		$has_stored  = ! empty( $this->settings['credentials_stored'] ) && ! empty( $this->settings['aws_secret_key_enc'] );
-		$placeholder = $has_stored ? '******** (stored)' : '';
-		echo '<input type="password" id="aws_secret_key" name="' . esc_attr( $this->settings_option ) . '[aws_secret_key]" value="" placeholder="' . esc_attr( $placeholder ) . '" class="regular-text" ' . esc_attr( $disabled ) . '/>';
-		echo '<p class="description">Optional when using IAM role. Leave blank to keep existing; enter a new secret to replace.</p>';
+		return $this->settings_manager->aws_secret_key_callback();
 	}
 
-	/**
-	 * AWS Region field callback.
-	 *
-	 * Renders the AWS Region field for the settings page.
-	 * Defaults to us-east-1 if not specified.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @return void
-	 */
 	public function aws_region_callback() {
-		$value = isset( $this->settings['aws_region'] ) ? $this->settings['aws_region'] : 'us-east-1';
-		echo '<input type="text" id="aws_region" name="' . esc_attr( $this->settings_option ) . '[aws_region]" value="' . esc_attr( $value ) . '" class="regular-text" />';
-		echo '<p class="description">AWS region (e.g., us-east-1, eu-west-2, ap-southeast-1). Default: us-east-1</p>';
+		return $this->settings_manager->aws_region_callback();
 	}
 
-	/**
-	 * Distribution ID field callback.
-	 *
-	 * Renders the CloudFront Distribution ID field for the settings page.
-	 * This is required for all invalidation requests.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @return void
-	 */
 	public function distribution_id_callback() {
-		$value = isset( $this->settings['distribution_id'] ) ? $this->settings['distribution_id'] : '';
-		echo '<input type="text" id="distribution_id" name="' . esc_attr( $this->settings_option ) . '[distribution_id]" value="' . esc_attr( $value ) . '" class="regular-text" />';
-		echo '<p class="description">CloudFront Distribution ID (13-14 uppercase characters, e.g., E1ABCDEFGHIJKL)</p>';
+		return $this->settings_manager->distribution_id_callback();
 	}
 
-	/**
-	 * Invalidation Paths field callback.
-	 *
-	 * Renders the Default Invalidation Paths field for the settings page.
-	 * These paths will be used for site-wide invalidations.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @return void
-	 */
 	public function invalidation_paths_callback() {
-		$value = isset( $this->settings['invalidation_paths'] ) ? $this->settings['invalidation_paths'] : '/*';
-		echo '<textarea id="invalidation_paths" name="' . esc_attr( $this->settings_option ) . '[invalidation_paths]" rows="3" class="large-text">' . esc_textarea( $value ) . '</textarea>';
-		echo '<p class="description">Enter paths to invalidate (one per line). Each path must start with /. Examples: /*, /blog/*, /images/logo.png</p>';
+		return $this->settings_manager->invalidation_paths_callback();
 	}
 
-	/**
-	 * Validate AWS region format.
-	 *
-	 * Validates that the AWS region follows the correct format pattern.
-	 * Examples: us-east-1, eu-west-2, ap-southeast-1
-	 *
-	 * @since 1.2.0
-	 * @access private
-	 * @param string $region AWS region to validate.
-	 * @return string|WP_Error Validated region or WP_Error on failure.
-	 */
-	private function validate_aws_region( $region ) {
-		$region = trim( strtolower( $region ) );
-
-		// Allow empty region (will use default).
-		if ( '' === $region ) {
-			return $region;
-		}
-
-		// Validate region format: xx-xxxx-# or xxx-xxxx-#.
-		if ( ! preg_match( '/^[a-z]{2,3}-[a-z]+-\d+$/', $region ) ) {
-			return new WP_Error(
-				'invalid_aws_region',
-				__( 'Invalid AWS region format. Please use format like: us-east-1, eu-west-2, ap-southeast-1', 'cloudfront-cache-invalidator' )
-			);
-		}
-
-		return $region;
-	}
-
-	/**
-	 * Validate CloudFront Distribution ID format.
-	 *
-	 * Validates and normalizes the CloudFront Distribution ID.
-	 * Distribution IDs are 13-14 uppercase alphanumeric characters.
-	 * Examples: E1ABCDEFGHIJKL, E2XYZ123456789
-	 *
-	 * @since 1.2.0
-	 * @access private
-	 * @param string $distribution_id Distribution ID to validate.
-	 * @return string|WP_Error Validated (uppercase) distribution ID or WP_Error on failure.
-	 */
-	private function validate_distribution_id( $distribution_id ) {
-		$distribution_id = trim( strtoupper( $distribution_id ) );
-
-		// Validate distribution ID format: 13-14 alphanumeric characters.
-		if ( ! preg_match( '/^[A-Z0-9]{13,14}$/', $distribution_id ) ) {
-			return new WP_Error(
-				'invalid_distribution_id',
-				__( 'Invalid CloudFront Distribution ID. Expected 13-14 uppercase alphanumeric characters (e.g., E1ABCDEFGHIJKL)', 'cloudfront-cache-invalidator' )
-			);
-		}
-
-		return $distribution_id;
-	}
-
-	/**
-	 * Validate invalidation paths format.
-	 *
-	 * Validates that each invalidation path starts with a forward slash.
-	 * CloudFront requires all paths to begin with /.
-	 * Examples: /*, /blog/*, /images/logo.png
-	 *
-	 * @since 1.2.0
-	 * @access private
-	 * @param string $paths Newline-separated invalidation paths.
-	 * @return string|WP_Error Validated paths or WP_Error on failure.
-	 */
-	private function validate_invalidation_paths( $paths ) {
-		// Split paths by newline and trim each.
-		$paths_array = array_map( 'trim', explode( "\n", $paths ) );
-
-		// Filter out empty lines.
-		$paths_array = array_filter(
-			$paths_array,
-			function ( $path ) {
-				return '' !== $path;
-			}
-		);
-
-		// Must have at least one path.
-		if ( empty( $paths_array ) ) {
-			return new WP_Error(
-				'empty_invalidation_paths',
-				__( 'At least one invalidation path is required.', 'cloudfront-cache-invalidator' )
-			);
-		}
-
-		// Validate each path starts with /.
-		foreach ( $paths_array as $path ) {
-			if ( '/' !== substr( $path, 0, 1 ) ) {
-				return new WP_Error(
-					'invalid_invalidation_path',
-					sprintf(
-						/* translators: %s: The invalid path */
-						__( 'Invalidation path "%s" must start with /. Example: /*, /blog/*, /images/', 'cloudfront-cache-invalidator' ),
-						esc_html( $path )
-					)
-				);
-			}
-		}
-
-		// Return validated paths joined by newline.
-		return implode( "\n", $paths_array );
-	}
-
-	/**
-	 * Validate settings.
-	 *
-	 * Sanitizes and validates user input from the settings form.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @param array $input The raw input from the settings form.
-	 * @return array Sanitized settings values.
-	 */
 	public function validate_settings( $input ) {
-		// Start with existing settings so we can preserve encrypted values when fields are left blank.
-		$new_input = $this->settings;
+		// First process credentials through the credential manager to preserve encryption handling.
+		// This encrypts keys and removes plaintext versions from the result.
+		$settings = $this->credential_manager->process_credential_submission( $input );
 
-		// IAM role checkbox.
-		$new_input['use_iam_role'] = isset( $input['use_iam_role'] ) ? '1' : '0';
+		// Ensure settings manager sees the updated snapshot for validation fallbacks.
+		$this->settings_manager->set_settings( $settings );
 
-		// Enforce HTTPS for credential submission.
-		$is_ssl = is_ssl();
-
-		$submitted_access = isset( $input['aws_access_key'] ) ? trim( $input['aws_access_key'] ) : '';
-		$submitted_secret = isset( $input['aws_secret_key'] ) ? trim( $input['aws_secret_key'] ) : '';
-
-		if ( ! $is_ssl && ( '' !== $submitted_access || '' !== $submitted_secret ) ) {
-			add_settings_error( $this->settings_option, 'cloudfront_https_required', __( 'AWS credentials cannot be saved over an insecure (HTTP) connection. Please use HTTPS.', 'cloudfront-cache-invalidator' ), 'error' );
-			// Do not modify stored credentials if submitted over HTTP.
-		} else {
-			// Access key handling.
-			if ( '' !== $submitted_access ) {
-				$encrypted = $this->encrypt_value( sanitize_text_field( $submitted_access ) );
-				if ( false !== $encrypted ) {
-					$new_input['aws_access_key_enc'] = $encrypted;
-					$new_input['credentials_stored'] = true;
-				}
-			}
-
-			// Secret key handling.
-			if ( '' !== $submitted_secret ) {
-				$encrypted = $this->encrypt_value( sanitize_text_field( $submitted_secret ) );
-				if ( false !== $encrypted ) {
-					$new_input['aws_secret_key_enc'] = $encrypted;
-					$new_input['credentials_stored'] = true;
-				}
-			}
-		}
-
-		// Never persist plaintext fields.
-		unset( $new_input['aws_access_key'], $new_input['aws_secret_key'] );
-
-		// Region validation.
-		if ( isset( $input['aws_region'] ) ) {
-			$region = sanitize_text_field( $input['aws_region'] );
-
-			$validated_region = $this->validate_aws_region( $region );
-			if ( is_wp_error( $validated_region ) ) {
-				add_settings_error(
-					$this->settings_option,
-					'invalid_aws_region',
-					$validated_region->get_error_message(),
-					'error'
-				);
-				// Keep existing or use default.
-				$new_input['aws_region'] = isset( $this->settings['aws_region'] ) ? $this->settings['aws_region'] : 'us-east-1';
-			} else {
-				$new_input['aws_region'] = $validated_region;
-			}
-		}
-
-		// Distribution ID validation.
-		if ( isset( $input['distribution_id'] ) ) {
-			$dist_id = sanitize_text_field( $input['distribution_id'] );
-
-			// Allow empty (user can clear the field).
-			if ( '' === $dist_id ) {
-				$new_input['distribution_id'] = '';
-			} else {
-				$validated_dist_id = $this->validate_distribution_id( $dist_id );
-				if ( is_wp_error( $validated_dist_id ) ) {
-					add_settings_error(
-						$this->settings_option,
-						'invalid_distribution_id',
-						$validated_dist_id->get_error_message(),
-						'error'
-					);
-					// Keep existing value.
-					$new_input['distribution_id'] = isset( $this->settings['distribution_id'] ) ? $this->settings['distribution_id'] : '';
-				} else {
-					$new_input['distribution_id'] = $validated_dist_id;
-				}
-			}
-		}
-
-		// Invalidation paths validation.
-		if ( isset( $input['invalidation_paths'] ) ) {
-			$paths = sanitize_textarea_field( $input['invalidation_paths'] );
-
-			$validated_paths = $this->validate_invalidation_paths( $paths );
-			if ( is_wp_error( $validated_paths ) ) {
-				add_settings_error(
-					$this->settings_option,
-					'invalid_invalidation_paths',
-					$validated_paths->get_error_message(),
-					'error'
-				);
-				// Keep existing or use default.
-				$new_input['invalidation_paths'] = isset( $this->settings['invalidation_paths'] ) ? $this->settings['invalidation_paths'] : '/*';
-			} else {
-				$new_input['invalidation_paths'] = $validated_paths;
-			}
-		}
-
-		// If neither encrypted value exists, clear the stored flag.
-		if ( empty( $new_input['aws_access_key_enc'] ) || empty( $new_input['aws_secret_key_enc'] ) ) {
-			unset( $new_input['aws_access_key_enc'], $new_input['aws_secret_key_enc'] );
-			unset( $new_input['credentials_stored'] );
-		}
-
-		return $new_input;
-	}
-
-	/**
-	 * Render the settings page.
-	 *
-	 * Outputs the HTML for the plugin's admin settings page,
-	 * including the settings form and manual invalidation button.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @return void
-	 */
-	public function render_settings_page() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( esc_html( __( 'You do not have sufficient permissions to access this page.', 'cloudfront-cache-invalidator' ) ) );
-		}
-		?>
-		<div class="wrap">
-			<h1>CloudFront Cache Invalidator</h1>
-
-			<?php if ( ! is_ssl() ) : ?>
-				<div class="notice notice-error">
-					<p><strong><?php esc_html_e( 'Warning:', 'cloudfront-cache-invalidator' ); ?></strong> <?php esc_html_e( 'You are not using HTTPS. AWS credentials will not be saved over HTTP. Please switch to HTTPS before entering access keys.', 'cloudfront-cache-invalidator' ); ?></p>
-				</div>
-			<?php endif; ?>
-
-			<div class="notice notice-info">
-				<p><strong>IAM Role Support:</strong> If your WordPress site is running on AWS (EC2, ECS, Elastic Beanstalk, etc.), you can use IAM roles for authentication instead of access keys. This is more secure and easier to manage.</p>
-				<p>To use this feature:</p>
-				<ol>
-					<li>Create an IAM role with CloudFront invalidation permissions</li>
-					<li>Attach the role to your EC2 instance or other AWS service</li>
-					<li>Check the "Use IAM Role" option below</li>
-				</ol>
-				<p>Example IAM policy for CloudFront invalidation:</p>
-				<pre>{
-	"Version": "2012-10-17",
-	"Statement": [
-	{
-		"Effect": "Allow",
-		"Action": [
-		"cloudfront:CreateInvalidation",
-		"cloudfront:GetInvalidation",
-		"cloudfront:ListInvalidations"
-		],
-		"Resource": "arn:aws:cloudfront::*:distribution/*"
-	}
-	]
-	}</pre>
-			</div>
-
-			<form method="post" action="options.php">
-				<?php
-				settings_fields( $this->settings_group );
-				do_settings_sections( 'cloudfront-cache-invalidator' );
-				submit_button();
-				?>
-			</form>
-			<hr>
-			<h2>Manual Invalidation</h2>
-			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-				<input type="hidden" name="action" value="cloudfront_invalidate_all">
-				<?php wp_nonce_field( 'manual_invalidation', 'cloudfront_invalidation_nonce' ); ?>
-				<p>
-					<input type="submit" name="cloudfront_invalidate_all" class="button button-primary" value="Invalidate All CloudFront Cache">
-				</p>
-			</form>
-		</div>
-		<?php
-	}
-
-	/**
-	 * Handle manual invalidation form submission.
-	 *
-	 * Processes the manual cache invalidation request via admin-post.php,
-	 * implementing POST-Redirect-GET pattern to prevent duplicate submissions.
-	 *
-	 * @since 1.1.1
-	 * @access public
-	 * @return void
-	 */
-	public function handle_manual_invalidation() {
-		// Check user permissions.
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( esc_html__( 'You do not have sufficient permissions to perform this action.', 'cloudfront-cache-invalidator' ) );
-		}
-
-		// Verify nonce.
-		check_admin_referer( 'manual_invalidation', 'cloudfront_invalidation_nonce' );
-
-		// Perform invalidation.
-		$result = $this->invalidate_all();
-
-		// Store result in transient for display after redirect.
-		$user_id       = get_current_user_id();
-		$transient_key = 'cloudfront_invalidation_notice_' . $user_id;
-
-		if ( is_wp_error( $result ) ) {
-			set_transient(
-				$transient_key,
-				array(
-					'type'    => 'error',
-					'message' => $result->get_error_message(),
-				),
-				60
-			);
-		} else {
-			set_transient(
-				$transient_key,
-				array(
-					'type'    => 'success',
-					'message' => __( 'CloudFront invalidation request has been sent successfully!', 'cloudfront-cache-invalidator' ),
-				),
-				60
-			);
-		}
-
-		// Redirect back to settings page.
-		$redirect_url = add_query_arg(
-			'page',
-			'cloudfront-cache-invalidator',
-			admin_url( 'options-general.php' )
+		// Remove plaintext credential keys from input before passing to settings validation.
+		// The credential manager has already handled encryption and removed these keys.
+		$input_for_validation = array_diff_key(
+			$input,
+			array_flip( array( 'aws_access_key', 'aws_secret_key' ) )
 		);
 
-		wp_safe_redirect( $redirect_url );
-		exit;
+		// For checkbox fields like use_iam_role, only include in merged data if it's in the original input.
+		// This ensures WordPress form behavior where unchecked checkboxes don't appear in form data.
+		$merged = array_merge( $settings, $input_for_validation );
+
+		// Remove use_iam_role from merged if it wasn't in the original input.
+		// This preserves the behavior that unchecked checkboxes don't override previous values
+		// in the validation flow - the settings_manager will default to '0' if not present.
+		if ( ! isset( $input['use_iam_role'] ) && isset( $merged['use_iam_role'] ) ) {
+			unset( $merged['use_iam_role'] );
+		}
+
+		// Validate non-credential fields. The credential manager has already processed credentials.
+		$validated = $this->settings_manager->validate_settings( $merged );
+
+		// Sync mirrored settings for legacy property and downstream uses.
+		$this->settings = $validated;
+		$this->settings_manager->set_settings( $validated );
+
+		return $validated;
 	}
 
-	/**
-	 * Display admin notices for manual invalidation results.
-	 *
-	 * Retrieves and displays success/error messages stored in transients
-	 * after manual invalidation redirects.
-	 *
-	 * @since 1.1.1
-	 * @access public
-	 * @return void
-	 */
+	public function render_settings_page() {
+		return $this->settings_manager->render_settings_page();
+	}
+
+	public function enqueue_admin_scripts( $hook ) {
+		return $this->admin_interface->enqueue_admin_scripts( $hook );
+	}
+
+	public function handle_manual_invalidation() {
+		return $this->admin_interface->handle_manual_invalidation();
+	}
+
 	public function display_invalidation_notices() {
-		// Only show on our settings page.
-		$screen = get_current_screen();
-		if ( ! $screen || 'settings_page_cloudfront-cache-invalidator' !== $screen->id ) {
-			return;
-		}
-
-		// Check for notice transient.
-		$user_id       = get_current_user_id();
-		$transient_key = 'cloudfront_invalidation_notice_' . $user_id;
-		$notice        = get_transient( $transient_key );
-
-		if ( $notice && is_array( $notice ) && isset( $notice['type'], $notice['message'] ) ) {
-			$notice_class   = 'error' === $notice['type'] ? 'notice-error' : 'notice-success';
-			$message_prefix = 'error' === $notice['type'] ? __( 'Error: ', 'cloudfront-cache-invalidator' ) : '';
-
-			printf(
-				'<div class="notice %s is-dismissible"><p>%s%s</p></div>',
-				esc_attr( $notice_class ),
-				esc_html( $message_prefix ),
-				esc_html( $notice['message'] )
-			);
-
-			// Delete transient after displaying (single-use).
-			delete_transient( $transient_key );
-		}
+		return $this->admin_interface->display_invalidation_notices();
 	}
 
-	/**
-	 * Invalidate cache when a post is updated.
-	 *
-	 * Triggers a CloudFront invalidation when a post is saved,
-	 * creating paths based on the post's permalink and related archives.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @param int     $post_id The ID of the post being saved.
-	 * @param WP_Post $post    The post object.
-	 * @return void
-	 */
+	// Invalidation wrappers.
 	public function invalidate_on_post_update( $post_id, $post ) {
-		// Skip if this is an autosave.
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-			return;
-		}
-
-		// Skip for revisions.
-		if ( wp_is_post_revision( $post_id ) ) {
-			return;
-		}
-
-		// Skip for auto drafts.
-		if ( 'auto-draft' === $post->post_status ) {
-			return;
-		}
-
-		// Get the permalink.
-		$permalink = get_permalink( $post_id );
-
-		if ( $permalink ) {
-			// Convert full URL to path.
-			$url_parts = wp_parse_url( $permalink );
-			$path      = isset( $url_parts['path'] ) ? $url_parts['path'] : '/';
-
-			// Invalidate the specific post URL and potentially related paths.
-			$paths = array( $path, $path . '*' );
-
-			// If it's a page that might be the front page, also invalidate the root.
-			if ( 'page' === $post->post_type && ( get_option( 'page_on_front' ) === $post_id || get_option( 'page_for_posts' ) === $post_id ) ) {
-				$paths[] = '/';
-				$paths[] = '/*';
-			}
-
-			// If archives might be affected (for posts or custom post types).
-			if ( 'page' !== $post->post_type ) {
-				// Get archive URL.
-				$archive_url = get_post_type_archive_link( $post->post_type );
-				if ( $archive_url ) {
-					$archive_parts = wp_parse_url( $archive_url );
-					$archive_path  = isset( $archive_parts['path'] ) ? $archive_parts['path'] : '/';
-					$paths[]       = $archive_path;
-					$paths[]       = $archive_path . '*';
-				}
-
-				// If categories/tags/terms are affected.
-				$taxonomies = get_object_taxonomies( $post->post_type );
-				foreach ( $taxonomies as $taxonomy ) {
-					$terms = get_the_terms( $post_id, $taxonomy );
-					if ( $terms && ! is_wp_error( $terms ) ) {
-						foreach ( $terms as $term ) {
-							$term_link = get_term_link( $term );
-							if ( ! is_wp_error( $term_link ) ) {
-								$term_parts = wp_parse_url( $term_link );
-								$term_path  = isset( $term_parts['path'] ) ? $term_parts['path'] : '/';
-								$paths[]    = $term_path;
-								$paths[]    = $term_path . '*';
-							}
-						}
-					}
-				}
-			}
-
-			// Send invalidation request.
-			$this->send_invalidation_request( array_unique( $paths ) );
-		}
+		return $this->invalidation_manager->invalidate_on_post_update( $post_id, $post );
 	}
 
-	/**
-	 * Invalidate cache when a post is deleted.
-	 *
-	 * Triggers a site-wide CloudFront invalidation when a post is deleted,
-	 * as determining specific affected paths is difficult after deletion.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @return void
-	 */
 	public function invalidate_on_post_delete() {
-		// We need to invalidate more broadly since the post URL is now gone.
-		$this->invalidate_all();
+		return $this->invalidation_manager->invalidate_on_post_delete();
 	}
 
-	/**
-	 * Invalidate cache when a term is updated.
-	 *
-	 * Triggers a CloudFront invalidation when a taxonomy term
-	 * (category, tag, etc.) is updated.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @param int    $term_id  The term ID.
-	 * @param int    $tt_id    The term taxonomy ID.
-	 * @param string $taxonomy The taxonomy slug.
-	 * @return void
-	 */
 	public function invalidate_on_term_update( $term_id, $tt_id, $taxonomy ) {
-
-		// Get the term link.
-		$term_link = get_term_link( $term_id, $taxonomy );
-
-		if ( ! is_wp_error( $term_link ) ) {
-			// Convert full URL to path.
-			$url_parts = wp_parse_url( $term_link );
-			$path      = isset( $url_parts['path'] ) ? $url_parts['path'] : '/';
-
-			// Invalidate the specific term URL and potentially related paths.
-			$paths = array( $path, $path . '*' );
-
-			// Send invalidation request.
-			$this->send_invalidation_request( $paths );
-		}
+		return $this->invalidation_manager->invalidate_on_term_update( $term_id, $tt_id, $taxonomy );
 	}
 
-	/**
-	 * Invalidate all cache.
-	 *
-	 * Triggers a CloudFront invalidation for all paths defined
-	 * in the default invalidation paths setting.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @return mixed WP_Error on failure, AWS result object on success
-	 */
 	public function invalidate_all() {
-
-		// Get default invalidation paths from settings.
-		$default_paths = isset( $this->settings['invalidation_paths'] ) ? $this->settings['invalidation_paths'] : '/*';
-		$paths         = array_map( 'trim', explode( "\n", $default_paths ) );
-
-		// Send invalidation request.
-		return $this->send_invalidation_request( $paths );
+		return $this->invalidation_manager->invalidate_all();
 	}
 
-	/**
-	 * Validate and sanitize an array of invalidation paths for CloudFront API.
-	 *
-	 * Ensures paths meet CloudFront requirements:
-	 * - Must start with /
-	 * - Limited to 3000 paths per invalidation (AWS limit)
-	 * - Removes empty or invalid paths
-	 *
-	 * @since 1.1.1
-	 * @access private
-	 * @param array $paths Array of paths to validate.
-	 * @return array|WP_Error Validated paths array or WP_Error if validation fails.
-	 */
-	private function sanitize_invalidation_paths_array( $paths ) {
-		if ( ! is_array( $paths ) || empty( $paths ) ) {
-			return new WP_Error( 'invalid_paths', 'Invalidation paths must be a non-empty array.' );
-		}
-
-		$validated_paths = array();
-
-		foreach ( $paths as $path ) {
-			// Ensure path is a string.
-			if ( ! is_string( $path ) ) {
-				continue;
-			}
-
-			// Trim whitespace.
-			$path = trim( $path );
-
-			// Skip empty paths.
-			if ( '' === $path ) {
-				continue;
-			}
-
-			// CloudFront requires paths to start with /.
-			if ( '/' !== substr( $path, 0, 1 ) ) {
-				$path = '/' . $path;
-			}
-
-			// Add to validated list.
-			$validated_paths[] = $path;
-		}
-
-		// Check if we have any valid paths after validation.
-		if ( empty( $validated_paths ) ) {
-			return new WP_Error( 'no_valid_paths', 'No valid invalidation paths provided.' );
-		}
-
-		// Remove duplicates.
-		$validated_paths = array_unique( $validated_paths );
-
-		// AWS CloudFront limit is 3000 paths per invalidation request.
-		if ( count( $validated_paths ) > 3000 ) {
-			return new WP_Error(
-				'too_many_paths',
-				sprintf(
-					'CloudFront allows a maximum of 3000 paths per invalidation request. You provided %d paths.',
-					count( $validated_paths )
-				)
-			);
-		}
-
-		return $validated_paths;
-	}
-
-	/**
-	 * Send invalidation request to CloudFront.
-	 *
-	 * Creates and sends an invalidation request to the CloudFront API
-	 * for the specified paths.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @param array $paths Array of paths to invalidate (e.g., ['/*', '/blog/*']).
-	 * @return mixed WP_Error on failure, AWS result object on success
-	 */
+	// CloudFront client wrapper.
 	public function send_invalidation_request( $paths = array( '/*' ) ) {
+		return $this->cloudfront_client->send_invalidation_request( $paths );
+	}
 
-		// Check if AWS SDK is available.
-		if ( ! class_exists( 'Aws\CloudFront\CloudFrontClient' ) ) {
-			// Try to load AWS SDK via manual path if autoloader didn't work.
-			if ( ! file_exists( plugin_dir_path( __FILE__ ) . 'vendor/autoload.php' ) ) {
-				return new WP_Error( 'sdk_missing', 'AWS SDK for PHP is not installed. Please run composer require aws/aws-sdk-php in the plugin directory.' );
-			}
-		}
+	/* -------------------------------------------------------------
+	 * Private compatibility wrappers for legacy tests (encryption & validation)
+	 * ----------------------------------------------------------- */
 
-		// Check if distribution ID is configured.
-		if ( ! isset( $this->settings['distribution_id'] ) || empty( $this->settings['distribution_id'] ) ) {
-			return new WP_Error( 'settings_missing', 'CloudFront Distribution ID not configured.' );
-		}
+	private function migrate_legacy_credentials( $settings ) {
+		return $this->credential_manager->migrate_legacy_credentials( $settings );
+	}
 
-		// Validate and sanitize paths before sending to AWS API.
-		$validated_paths = $this->sanitize_invalidation_paths_array( $paths );
-		if ( is_wp_error( $validated_paths ) ) {
-			return $validated_paths;
-		}
+	private function get_encryption_key() {
+		$reflector = new ReflectionClass( $this->credential_manager );
+		$method    = $reflector->getMethod( 'get_encryption_key' );
+		$method->setAccessible( true );
+		return $method->invoke( $this->credential_manager );
+	}
 
-		try {
-			// Set up AWS CloudFront client config.
-			$config = array(
-				'version' => 'latest',
-				'region'  => isset( $this->settings['aws_region'] ) ? $this->settings['aws_region'] : 'us-east-1',
-			);
+	private function encrypt_value( $plaintext ) {
+		$reflector = new ReflectionClass( $this->credential_manager );
+		$method    = $reflector->getMethod( 'encrypt_value' );
+		$method->setAccessible( true );
+		return $method->invoke( $this->credential_manager, $plaintext );
+	}
 
-			// Use IAM role or keys based on settings.
-			$use_iam_role = isset( $this->settings['use_iam_role'] ) && '1' === $this->settings['use_iam_role'];
+	private function decrypt_value( $encoded ) {
+		$reflector = new ReflectionClass( $this->credential_manager );
+		$method    = $reflector->getMethod( 'decrypt_value' );
+		$method->setAccessible( true );
+		return $method->invoke( $this->credential_manager, $encoded );
+	}
 
-			// Only add credentials if not using IAM role and credentials are resolved.
-			if ( ! $use_iam_role ) {
-				$creds = $this->resolve_credentials();
-				if ( $creds && ! empty( $creds['key'] ) && ! empty( $creds['secret'] ) ) {
-					$config['credentials'] = $creds;
-				}
-			}
+	private function get_env_or_option( $constant_name, $env_name, $option_key ) {
+		$reflector = new ReflectionClass( $this->credential_manager );
+		$method    = $reflector->getMethod( 'get_env_or_option' );
+		$method->setAccessible( true );
+		return $method->invoke( $this->credential_manager, $constant_name, $env_name, $option_key );
+	}
 
-			// Set up AWS CloudFront client.
-			$client = new Aws\CloudFront\CloudFrontClient( $config );
+	private function resolve_credentials() {
+		return $this->credential_manager->resolve_credentials();
+	}
 
-			// Create a unique reference ID for this invalidation.
-			$caller_reference = 'wp-' . time() . '-' . wp_generate_password( 6, false );
+	private function validate_aws_region( $region ) {
+		$reflector = new ReflectionClass( $this->settings_manager );
+		$method    = $reflector->getMethod( 'validate_aws_region' );
+		$method->setAccessible( true );
+		return $method->invoke( $this->settings_manager, $region );
+	}
 
-			// Send invalidation request.
-			$result = $client->createInvalidation(
-				array(
-					'DistributionId'    => $this->settings['distribution_id'],
-					'InvalidationBatch' => array(
-						'CallerReference' => $caller_reference,
-						'Paths'           => array(
-							'Quantity' => count( $validated_paths ),
-							'Items'    => $validated_paths,
-						),
-					),
-				)
-			);
+	private function validate_distribution_id( $distribution_id ) {
+		$reflector = new ReflectionClass( $this->settings_manager );
+		$method    = $reflector->getMethod( 'validate_distribution_id' );
+		$method->setAccessible( true );
+		return $method->invoke( $this->settings_manager, $distribution_id );
+	}
 
-			// Expose a hook so sites can optionally log or monitor invalidations without using error_log().
-			do_action( 'notglossy_cloudfront_invalidation_sent', $validated_paths, $result );
+	private function validate_invalidation_paths( $paths ) {
+		$reflector = new ReflectionClass( $this->settings_manager );
+		$method    = $reflector->getMethod( 'validate_invalidation_paths' );
+		$method->setAccessible( true );
+		return $method->invoke( $this->settings_manager, $paths );
+	}
 
-			return $result;
-
-		} catch ( Exception $e ) {
-			do_action( 'notglossy_cloudfront_invalidation_error', $e );
-			return new WP_Error( 'invalidation_failed', $e->getMessage() );
-		}
+	private function sanitize_invalidation_paths_array( $paths ) {
+		return $this->path_validator->sanitize_invalidation_paths_array( $paths );
 	}
 }

--- a/includes/class-notglossy-cloudfront-cache-invalidator.php
+++ b/includes/class-notglossy-cloudfront-cache-invalidator.php
@@ -89,8 +89,9 @@ class NotGlossy_CloudFront_Cache_Invalidator {
 	 * Constructor sets up all components and registers hooks.
 	 */
 	public function __construct() {
-		$this->settings_manager     = new NotGlossy_CloudFront_Settings_Manager();
-		$this->credential_manager   = new NotGlossy_CloudFront_Credential_Manager( $this->settings_manager );
+		$this->settings_manager   = new NotGlossy_CloudFront_Settings_Manager();
+		$this->credential_manager = new NotGlossy_CloudFront_Credential_Manager( $this->settings_manager );
+		$this->settings_manager->set_credential_manager( $this->credential_manager );
 		$this->path_validator       = new NotGlossy_CloudFront_Path_Validator();
 		$this->cloudfront_client    = new NotGlossy_CloudFront_Client( $this->settings_manager, $this->credential_manager, $this->path_validator );
 		$this->invalidation_manager = new NotGlossy_CloudFront_Invalidation_Manager( $this->settings_manager, $this->cloudfront_client );
@@ -271,28 +272,28 @@ class NotGlossy_CloudFront_Cache_Invalidator {
 	private function get_encryption_key() {
 		$reflector = new ReflectionClass( $this->credential_manager );
 		$method    = $reflector->getMethod( 'get_encryption_key' );
-		$method->setAccessible( true );
+
 		return $method->invoke( $this->credential_manager );
 	}
 
 	private function encrypt_value( $plaintext ) {
 		$reflector = new ReflectionClass( $this->credential_manager );
 		$method    = $reflector->getMethod( 'encrypt_value' );
-		$method->setAccessible( true );
+
 		return $method->invoke( $this->credential_manager, $plaintext );
 	}
 
 	private function decrypt_value( $encoded ) {
 		$reflector = new ReflectionClass( $this->credential_manager );
 		$method    = $reflector->getMethod( 'decrypt_value' );
-		$method->setAccessible( true );
+
 		return $method->invoke( $this->credential_manager, $encoded );
 	}
 
 	private function get_env_or_option( $constant_name, $env_name, $option_key ) {
 		$reflector = new ReflectionClass( $this->credential_manager );
 		$method    = $reflector->getMethod( 'get_env_or_option' );
-		$method->setAccessible( true );
+
 		return $method->invoke( $this->credential_manager, $constant_name, $env_name, $option_key );
 	}
 
@@ -303,21 +304,21 @@ class NotGlossy_CloudFront_Cache_Invalidator {
 	private function validate_aws_region( $region ) {
 		$reflector = new ReflectionClass( $this->settings_manager );
 		$method    = $reflector->getMethod( 'validate_aws_region' );
-		$method->setAccessible( true );
+
 		return $method->invoke( $this->settings_manager, $region );
 	}
 
 	private function validate_distribution_id( $distribution_id ) {
 		$reflector = new ReflectionClass( $this->settings_manager );
 		$method    = $reflector->getMethod( 'validate_distribution_id' );
-		$method->setAccessible( true );
+
 		return $method->invoke( $this->settings_manager, $distribution_id );
 	}
 
 	private function validate_invalidation_paths( $paths ) {
 		$reflector = new ReflectionClass( $this->settings_manager );
 		$method    = $reflector->getMethod( 'validate_invalidation_paths' );
-		$method->setAccessible( true );
+
 		return $method->invoke( $this->settings_manager, $paths );
 	}
 

--- a/includes/class-notglossy-cloudfront-client.php
+++ b/includes/class-notglossy-cloudfront-client.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * CloudFront Client for Cache Invalidation.
+ *
+ * Handles AWS CloudFront API integration, invalidation request creation,
+ * and error handling.
+ *
+ * @since 1.2.0
+ * @package CloudFrontCacheInvalidator
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * CloudFront Client class.
+ *
+ * @since 1.2.0
+ */
+class NotGlossy_CloudFront_Client {
+
+	/**
+	 * Settings manager instance.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @var NotGlossy_CloudFront_Settings_Manager
+	 */
+	private $settings_manager;
+
+	/**
+	 * Credential manager instance.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @var NotGlossy_CloudFront_Credential_Manager
+	 */
+	private $credential_manager;
+
+	/**
+	 * Path validator instance.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @var NotGlossy_CloudFront_Path_Validator
+	 */
+	private $path_validator;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @param NotGlossy_CloudFront_Settings_Manager   $settings_manager   Settings manager instance.
+	 * @param NotGlossy_CloudFront_Credential_Manager $credential_manager Credential manager instance.
+	 * @param NotGlossy_CloudFront_Path_Validator     $path_validator     Path validator instance.
+	 */
+	public function __construct(
+		NotGlossy_CloudFront_Settings_Manager $settings_manager,
+		NotGlossy_CloudFront_Credential_Manager $credential_manager,
+		NotGlossy_CloudFront_Path_Validator $path_validator
+	) {
+		$this->settings_manager   = $settings_manager;
+		$this->credential_manager = $credential_manager;
+		$this->path_validator     = $path_validator;
+	}
+
+	/**
+	 * Send invalidation request to CloudFront.
+	 *
+	 * Creates and sends an invalidation request to the CloudFront API
+	 * for the specified paths.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @param array $paths Array of paths to invalidate (e.g., ['/*', '/blog/*']).
+	 * @return mixed WP_Error on failure, AWS result object on success.
+	 */
+	public function send_invalidation_request( $paths = array( '/*' ) ) {
+
+		// Check if AWS SDK is available.
+		if ( ! class_exists( 'Aws\CloudFront\CloudFrontClient' ) ) {
+			// Try to load AWS SDK via manual path if autoloader didn't work.
+			if ( ! file_exists( plugin_dir_path( __FILE__ ) . 'vendor/autoload.php' ) ) {
+				return new WP_Error( 'sdk_missing', 'AWS SDK for PHP is not installed. Please run composer require aws/aws-sdk-php in the plugin directory.' );
+			}
+		}
+
+		// Check if distribution ID is configured.
+		$distribution_id = $this->credential_manager->get_distribution_id();
+		if ( empty( $distribution_id ) ) {
+			return new WP_Error( 'settings_missing', 'CloudFront Distribution ID not configured.' );
+		}
+
+		// Validate and sanitize paths before sending to AWS API.
+		$validated_paths = $this->path_validator->sanitize_invalidation_paths_array( $paths );
+		if ( is_wp_error( $validated_paths ) ) {
+			return $validated_paths;
+		}
+
+		try {
+			// Set up AWS CloudFront client config.
+			$config = array(
+				'Version' => 'latest',
+				'region'  => $this->credential_manager->get_aws_region(),
+			);
+
+			// Use IAM role or keys based on settings.
+			$use_iam_role = $this->credential_manager->is_using_iam_role();
+
+			// Only add credentials if not using IAM role and credentials are resolved.
+			if ( ! $use_iam_role ) {
+				$creds = $this->credential_manager->resolve_credentials();
+				if ( $creds && ! empty( $creds['key'] ) && ! empty( $creds['secret'] ) ) {
+					$config['credentials'] = $creds;
+				}
+			}
+
+			// Set up AWS CloudFront client.
+			$client = new Aws\CloudFront\CloudFrontClient( $config );
+
+			// Create a unique reference ID for this invalidation.
+			$caller_reference = 'wp-' . time() . '-' . wp_generate_password( 6, false );
+
+			// Send invalidation request.
+			$result = $client->createInvalidation(
+				array(
+					'DistributionId'    => $distribution_id,
+					'InvalidationBatch' => array(
+						'CallerReference' => $caller_reference,
+						'Paths'           => array(
+							'Quantity' => count( $validated_paths ),
+							'Items'    => $validated_paths,
+						),
+					),
+				)
+			);
+
+			// Expose a hook so sites can optionally log or monitor invalidations without using error_log().
+			do_action( 'notglossy_cloudfront_invalidation_sent', $validated_paths, $result );
+
+			return $result;
+
+		} catch ( Exception $e ) {
+			do_action( 'notglossy_cloudfront_invalidation_error', $e );
+			return new WP_Error( 'invalidation_failed', $e->getMessage() );
+		}
+	}
+}

--- a/includes/class-notglossy-cloudfront-credential-manager.php
+++ b/includes/class-notglossy-cloudfront-credential-manager.php
@@ -1,0 +1,338 @@
+<?php
+/**
+ * Credential Manager for CloudFront Cache Invalidator.
+ *
+ * Handles secure credential management including AES-256-CBC encryption,
+ * environment variable resolution, and IAM role vs access key logic.
+ *
+ * @since 1.2.0
+ * @package CloudFrontCacheInvalidator
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Credential Manager class.
+ *
+ * Responsible for secure credential handling, encryption/decryption,
+ * environment variable resolution, and IAM role management.
+ *
+ * @since 1.2.0
+ */
+class NotGlossy_CloudFront_Credential_Manager {
+
+	/**
+	 * Encryption cipher.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @var string CIPHER Encryption algorithm.
+	 */
+	const CIPHER = 'AES-256-CBC';
+
+	/**
+	 * Settings manager instance.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @var NotGlossy_CloudFront_Settings_Manager $settings_manager Settings manager instance.
+	 */
+	private $settings_manager;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @param NotGlossy_CloudFront_Settings_Manager $settings_manager Settings manager instance.
+	 */
+	public function __construct( NotGlossy_CloudFront_Settings_Manager $settings_manager ) {
+		$this->settings_manager = $settings_manager;
+	}
+
+	/**
+	 * Migrate legacy plaintext credentials to encrypted storage.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @param array $settings Current settings array.
+	 * @return array Updated settings.
+	 */
+	public function migrate_legacy_credentials( $settings ) {
+		$updated = false;
+
+		if ( isset( $settings['aws_access_key'] ) && ! empty( $settings['aws_access_key'] ) ) {
+			$encrypted = $this->encrypt_value( $settings['aws_access_key'] );
+			if ( false !== $encrypted ) {
+				$settings['aws_access_key_enc'] = $encrypted;
+				$settings['credentials_stored'] = true;
+				$updated                        = true;
+			}
+			unset( $settings['aws_access_key'] );
+		}
+
+		if ( isset( $settings['aws_secret_key'] ) && ! empty( $settings['aws_secret_key'] ) ) {
+			$encrypted = $this->encrypt_value( $settings['aws_secret_key'] );
+			if ( false !== $encrypted ) {
+				$settings['aws_secret_key_enc'] = $encrypted;
+				$settings['credentials_stored'] = true;
+				$updated                        = true;
+			}
+			unset( $settings['aws_secret_key'] );
+		}
+
+		if ( $updated ) {
+			update_option( $this->settings_manager->get_settings_option(), $settings );
+		}
+
+		return $settings;
+	}
+
+	/**
+	 * Get derived encryption key from WordPress salts.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @return string Binary encryption key.
+	 */
+	private function get_encryption_key() {
+		$parts = array();
+
+		if ( defined( 'AUTH_KEY' ) ) {
+			$parts[] = AUTH_KEY;
+		}
+
+		if ( defined( 'SECURE_AUTH_KEY' ) ) {
+			$parts[] = SECURE_AUTH_KEY;
+		}
+
+		if ( empty( $parts ) ) {
+			$parts[] = wp_salt( 'auth' );
+		}
+
+		return hash( 'sha256', implode( '', $parts ), true );
+	}
+
+	/**
+	 * Encrypt a value using AES-256-CBC.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @param string $plaintext Plaintext to encrypt.
+	 * @return string|false JSON encoded ciphertext payload or false on failure.
+	 */
+	private function encrypt_value( $plaintext ) {
+		if ( '' === $plaintext ) {
+			return false;
+		}
+
+		$key = $this->get_encryption_key();
+		$iv  = random_bytes( 16 );
+
+		$ciphertext = openssl_encrypt( $plaintext, self::CIPHER, $key, OPENSSL_RAW_DATA, $iv );
+		if ( false === $ciphertext ) {
+			return false;
+		}
+
+		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Used for encryption, not obfuscation.
+		return wp_json_encode(
+			array(
+				'iv'    => base64_encode( $iv ),
+				'value' => base64_encode( $ciphertext ),
+			)
+		);
+		// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+	}
+
+	/**
+	 * Decrypt a value previously encrypted with encrypt_value().
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @param string $encoded JSON encoded payload from encrypt_value().
+	 * @return string|false Plaintext or false on failure.
+	 */
+	private function decrypt_value( $encoded ) {
+		if ( empty( $encoded ) ) {
+			return false;
+		}
+
+		$data = json_decode( $encoded, true );
+		if ( ! is_array( $data ) || empty( $data['iv'] ) || empty( $data['value'] ) ) {
+			return false;
+		}
+
+		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Used for decryption, not obfuscation.
+		$iv         = base64_decode( $data['iv'], true );
+		$ciphertext = base64_decode( $data['value'], true );
+		// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+
+		if ( false === $iv || false === $ciphertext ) {
+			return false;
+		}
+
+		$plaintext = openssl_decrypt( $ciphertext, self::CIPHER, $this->get_encryption_key(), OPENSSL_RAW_DATA, $iv );
+
+		return false === $plaintext ? false : $plaintext;
+	}
+
+	/**
+	 * Resolve value from constant/env or encrypted option.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @param string $constant_name Constant name.
+	 * @param string $env_name      Environment variable name.
+	 * @param string $option_key    Option key for encrypted value.
+	 * @return string|null
+	 */
+	private function get_env_or_option( $constant_name, $env_name, $option_key ) {
+		if ( defined( $constant_name ) && constant( $constant_name ) ) {
+			return constant( $constant_name );
+		}
+
+		$env_value = getenv( $env_name );
+		if ( $env_value ) {
+			return $env_value;
+		}
+
+		$encrypted_value = $this->settings_manager->get_setting( $option_key );
+		if ( $encrypted_value ) {
+			return $this->decrypt_value( $encrypted_value );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resolve AWS credentials honoring constants/env first.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return array|null Array with key/secret or null.
+	 */
+	public function resolve_credentials() {
+		$access_key = $this->get_env_or_option( 'CLOUDFRONT_AWS_ACCESS_KEY', 'CLOUDFRONT_AWS_ACCESS_KEY', 'aws_access_key_enc' );
+		$secret_key = $this->get_env_or_option( 'CLOUDFRONT_AWS_SECRET_KEY', 'CLOUDFRONT_AWS_SECRET_KEY', 'aws_secret_key_enc' );
+
+		if ( $access_key && $secret_key ) {
+			return array(
+				'key'    => $access_key,
+				'secret' => $secret_key,
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Check if credentials are available.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return bool True if credentials are available, false otherwise.
+	 */
+	public function has_credentials() {
+		$credentials = $this->resolve_credentials();
+		return null !== $credentials && ! empty( $credentials['key'] ) && ! empty( $credentials['secret'] );
+	}
+
+	/**
+	 * Check if using IAM role.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return bool True if IAM role is enabled, false otherwise.
+	 */
+	public function is_using_iam_role() {
+		return $this->settings_manager->get_setting( 'use_iam_role' ) === '1';
+	}
+
+	/**
+	 * Get AWS region.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return string AWS region.
+	 */
+	public function get_aws_region() {
+		return $this->settings_manager->get_setting( 'aws_region', 'us-east-1' );
+	}
+
+	/**
+	 * Get CloudFront distribution ID.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return string CloudFront distribution ID.
+	 */
+	public function get_distribution_id() {
+		return $this->settings_manager->get_setting( 'distribution_id', '' );
+	}
+
+	/**
+	 * Get default invalidation paths.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return string Default invalidation paths.
+	 */
+	public function get_default_invalidation_paths() {
+		return $this->settings_manager->get_setting( 'invalidation_paths', '/*' );
+	}
+
+	/**
+	 * Process credential submission from settings form.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @param array $input Raw input from settings form.
+	 * @return array Updated settings with encrypted credentials.
+	 */
+	public function process_credential_submission( $input ) {
+		$settings = $this->settings_manager->get_settings();
+
+		// Enforce HTTPS for credential submission.
+		$is_ssl = is_ssl();
+
+		$submitted_access = isset( $input['aws_access_key'] ) ? trim( $input['aws_access_key'] ) : '';
+		$submitted_secret = isset( $input['aws_secret_key'] ) ? trim( $input['aws_secret_key'] ) : '';
+
+		if ( ! $is_ssl && ( '' !== $submitted_access || '' !== $submitted_secret ) ) {
+			add_settings_error( $this->settings_manager->get_settings_option(), 'cloudfront_https_required', __( 'AWS credentials cannot be saved over an insecure (HTTP) connection. Please use HTTPS.', 'cloudfront-cache-invalidator' ), 'error' );
+			// Do not modify stored credentials if submitted over HTTP.
+			return $settings;
+		}
+
+		// Access key handling.
+		if ( '' !== $submitted_access ) {
+			$encrypted = $this->encrypt_value( sanitize_text_field( $submitted_access ) );
+			if ( false !== $encrypted ) {
+				$settings['aws_access_key_enc'] = $encrypted;
+				$settings['credentials_stored'] = true;
+			}
+		}
+
+		// Secret key handling.
+		if ( '' !== $submitted_secret ) {
+			$encrypted = $this->encrypt_value( sanitize_text_field( $submitted_secret ) );
+			if ( false !== $encrypted ) {
+				$settings['aws_secret_key_enc'] = $encrypted;
+				$settings['credentials_stored'] = true;
+			}
+		}
+
+		// Never persist plaintext fields.
+		unset( $settings['aws_access_key'], $settings['aws_secret_key'] );
+
+		// If neither encrypted value exists, clear the stored flag.
+		if ( empty( $settings['aws_access_key_enc'] ) || empty( $settings['aws_secret_key_enc'] ) ) {
+			unset( $settings['aws_access_key_enc'], $settings['aws_secret_key_enc'] );
+			unset( $settings['credentials_stored'] );
+		}
+
+		return $settings;
+	}
+}

--- a/includes/class-notglossy-cloudfront-credential-manager.php
+++ b/includes/class-notglossy-cloudfront-credential-manager.php
@@ -2,7 +2,7 @@
 /**
  * Credential Manager for CloudFront Cache Invalidator.
  *
- * Handles secure credential management including AES-256-CBC encryption,
+ * Handles secure credential management including libsodium authenticated encryption,
  * environment variable resolution, and IAM role vs access key logic.
  *
  * @since 1.2.0
@@ -22,15 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.2.0
  */
 class NotGlossy_CloudFront_Credential_Manager {
-
-	/**
-	 * Encryption cipher.
-	 *
-	 * @since 1.2.0
-	 * @access private
-	 * @var string CIPHER Encryption algorithm.
-	 */
-	const CIPHER = 'AES-256-CBC';
 
 	/**
 	 * Settings manager instance.
@@ -116,7 +107,7 @@ class NotGlossy_CloudFront_Credential_Manager {
 	}
 
 	/**
-	 * Encrypt a value using AES-256-CBC.
+	 * Encrypt a value using libsodium authenticated encryption.
 	 *
 	 * @since 1.2.0
 	 * @access private
@@ -128,18 +119,15 @@ class NotGlossy_CloudFront_Credential_Manager {
 			return false;
 		}
 
-		$key = $this->get_encryption_key();
-		$iv  = random_bytes( 16 );
+		$key   = $this->get_encryption_key();
+		$nonce = random_bytes( SODIUM_CRYPTO_SECRETBOX_NONCEBYTES );
 
-		$ciphertext = openssl_encrypt( $plaintext, self::CIPHER, $key, OPENSSL_RAW_DATA, $iv );
-		if ( false === $ciphertext ) {
-			return false;
-		}
+		$ciphertext = sodium_crypto_secretbox( $plaintext, $nonce, $key );
 
 		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Used for encryption, not obfuscation.
 		return wp_json_encode(
 			array(
-				'iv'    => base64_encode( $iv ),
+				'nonce' => base64_encode( $nonce ),
 				'value' => base64_encode( $ciphertext ),
 			)
 		);
@@ -148,6 +136,9 @@ class NotGlossy_CloudFront_Credential_Manager {
 
 	/**
 	 * Decrypt a value previously encrypted with encrypt_value().
+	 *
+	 * Supports both current libsodium payloads (nonce key) and legacy
+	 * AES-256-CBC payloads (iv key) for backwards compatibility.
 	 *
 	 * @since 1.2.0
 	 * @access private
@@ -160,10 +151,62 @@ class NotGlossy_CloudFront_Credential_Manager {
 		}
 
 		$data = json_decode( $encoded, true );
-		if ( ! is_array( $data ) || empty( $data['iv'] ) || empty( $data['value'] ) ) {
+		if ( ! is_array( $data ) || empty( $data['value'] ) ) {
 			return false;
 		}
 
+		// Current libsodium format (nonce key).
+		if ( ! empty( $data['nonce'] ) ) {
+			return $this->decrypt_sodium( $data );
+		}
+
+		// Legacy AES-256-CBC format (iv key).
+		if ( ! empty( $data['iv'] ) ) {
+			return $this->decrypt_legacy_cbc( $data );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Decrypt a libsodium authenticated encryption payload.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @param array $data Decoded JSON with nonce and value keys.
+	 * @return string|false Plaintext or false on failure.
+	 */
+	private function decrypt_sodium( $data ) {
+		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Used for decryption, not obfuscation.
+		$nonce      = base64_decode( $data['nonce'], true );
+		$ciphertext = base64_decode( $data['value'], true );
+		// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+
+		if ( false === $nonce || false === $ciphertext ) {
+			return false;
+		}
+
+		try {
+			$plaintext = sodium_crypto_secretbox_open( $ciphertext, $nonce, $this->get_encryption_key() );
+		} catch ( SodiumException $e ) {
+			return false;
+		}
+
+		return false === $plaintext ? false : $plaintext;
+	}
+
+	/**
+	 * Decrypt a legacy AES-256-CBC payload.
+	 *
+	 * Retained for backwards compatibility with credentials encrypted before
+	 * the migration to libsodium. These will be re-encrypted on next save.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @param array $data Decoded JSON with iv and value keys.
+	 * @return string|false Plaintext or false on failure.
+	 */
+	private function decrypt_legacy_cbc( $data ) {
 		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Used for decryption, not obfuscation.
 		$iv         = base64_decode( $data['iv'], true );
 		$ciphertext = base64_decode( $data['value'], true );
@@ -173,7 +216,7 @@ class NotGlossy_CloudFront_Credential_Manager {
 			return false;
 		}
 
-		$plaintext = openssl_decrypt( $ciphertext, self::CIPHER, $this->get_encryption_key(), OPENSSL_RAW_DATA, $iv );
+		$plaintext = openssl_decrypt( $ciphertext, 'AES-256-CBC', $this->get_encryption_key(), OPENSSL_RAW_DATA, $iv );
 
 		return false === $plaintext ? false : $plaintext;
 	}

--- a/includes/class-notglossy-cloudfront-invalidation-manager.php
+++ b/includes/class-notglossy-cloudfront-invalidation-manager.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Invalidation Manager for CloudFront Cache Invalidator.
+ *
+ * Handles WordPress hook registration and invalidation logic for posts,
+ * terms, and site-wide events.
+ *
+ * @since 1.2.0
+ * @package CloudFrontCacheInvalidator
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Invalidation Manager class.
+ *
+ * @since 1.2.0
+ */
+class NotGlossy_CloudFront_Invalidation_Manager {
+
+	/**
+	 * Settings manager instance.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @var NotGlossy_CloudFront_Settings_Manager
+	 */
+	private $settings_manager;
+
+	/**
+	 * CloudFront client instance.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @var NotGlossy_CloudFront_Client
+	 */
+	private $cloudfront_client;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @param NotGlossy_CloudFront_Settings_Manager $settings_manager Settings manager instance.
+	 * @param NotGlossy_CloudFront_Client           $cloudfront_client CloudFront client instance.
+	 */
+	public function __construct( NotGlossy_CloudFront_Settings_Manager $settings_manager, NotGlossy_CloudFront_Client $cloudfront_client ) {
+		$this->settings_manager  = $settings_manager;
+		$this->cloudfront_client = $cloudfront_client;
+	}
+
+	/**
+	 * Register WordPress hooks for invalidation triggers.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return void
+	 */
+	public function register_hooks() {
+		// Content updates.
+		add_action( 'save_post', array( $this, 'invalidate_on_post_update' ), 10, 3 );
+		add_action( 'deleted_post', array( $this, 'invalidate_on_post_delete' ) );
+
+		// Theme and customizer changes.
+		add_action( 'switch_theme', array( $this, 'invalidate_all' ) );
+		add_action( 'customize_save_after', array( $this, 'invalidate_all' ) );
+		add_action( 'update_option_permalink_structure', array( $this, 'invalidate_all' ) );
+
+		// Plugin activation/deactivation can affect URLs.
+		add_action( 'activated_plugin', array( $this, 'invalidate_all' ) );
+		add_action( 'deactivated_plugin', array( $this, 'invalidate_all' ) );
+
+		// Menus and widgets.
+		add_action( 'wp_update_nav_menu', array( $this, 'invalidate_all' ) );
+		add_action( 'update_option_sidebars_widgets', array( $this, 'invalidate_all' ) );
+
+		// Terms.
+		add_action( 'edited_term', array( $this, 'invalidate_on_term_update' ), 10, 3 );
+	}
+
+	/**
+	 * Invalidate cache when a post is updated.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @param int     $post_id The ID of the post being saved.
+	 * @param WP_Post $post    The post object.
+	 * @return void
+	 */
+	public function invalidate_on_post_update( $post_id, $post ) {
+		// Skip if this is an autosave.
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		// Skip for revisions.
+		if ( wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+
+		// Skip for auto drafts.
+		if ( 'auto-draft' === $post->post_status ) {
+			return;
+		}
+
+		$permalink = get_permalink( $post_id );
+		if ( ! $permalink ) {
+			return;
+		}
+
+		$url_parts = wp_parse_url( $permalink );
+		$path      = isset( $url_parts['path'] ) ? $url_parts['path'] : '/';
+
+		$paths = array( $path, $path . '*' );
+
+		// If it's a front page or posts page, also invalidate root.
+		if ( 'page' === $post->post_type && ( get_option( 'page_on_front' ) === $post_id || get_option( 'page_for_posts' ) === $post_id ) ) {
+			$paths[] = '/';
+			$paths[] = '/*';
+		}
+
+		// Archive URLs for non-page post types.
+		if ( 'page' !== $post->post_type ) {
+			$archive_url = get_post_type_archive_link( $post->post_type );
+			if ( $archive_url ) {
+				$archive_parts = wp_parse_url( $archive_url );
+				$archive_path  = isset( $archive_parts['path'] ) ? $archive_parts['path'] : '/';
+				$paths[]       = $archive_path;
+				$paths[]       = $archive_path . '*';
+			}
+
+			// Term archives.
+			$taxonomies = get_object_taxonomies( $post->post_type );
+			foreach ( $taxonomies as $taxonomy ) {
+				$terms = get_the_terms( $post_id, $taxonomy );
+				if ( $terms && ! is_wp_error( $terms ) ) {
+					foreach ( $terms as $term ) {
+						$term_link = get_term_link( $term );
+						if ( ! is_wp_error( $term_link ) ) {
+							$term_parts = wp_parse_url( $term_link );
+							$term_path  = isset( $term_parts['path'] ) ? $term_parts['path'] : '/';
+							$paths[]    = $term_path;
+							$paths[]    = $term_path . '*';
+						}
+					}
+				}
+			}
+		}
+
+		$this->cloudfront_client->send_invalidation_request( array_unique( $paths ) );
+	}
+
+	/**
+	 * Invalidate cache when a post is deleted.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return void
+	 */
+	public function invalidate_on_post_delete() {
+		// Invalidate broadly since specific URL is removed.
+		$this->invalidate_all();
+	}
+
+	/**
+	 * Invalidate cache when a term is updated.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @param int    $term_id  The term ID.
+	 * @param int    $tt_id    The term taxonomy ID.
+	 * @param string $taxonomy The taxonomy slug.
+	 * @return void
+	 */
+	public function invalidate_on_term_update( $term_id, $tt_id, $taxonomy ) {
+		$term_link = get_term_link( $term_id, $taxonomy );
+		if ( is_wp_error( $term_link ) ) {
+			return;
+		}
+
+		$url_parts = wp_parse_url( $term_link );
+		$path      = isset( $url_parts['path'] ) ? $url_parts['path'] : '/';
+
+		$paths = array( $path, $path . '*' );
+
+		$this->cloudfront_client->send_invalidation_request( $paths );
+	}
+
+	/**
+	 * Invalidate all cache using default paths.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return mixed WP_Error on failure, AWS result object on success.
+	 */
+	public function invalidate_all() {
+		$default_paths = $this->settings_manager->get_setting( 'invalidation_paths', '/*' );
+		$paths         = array_map( 'trim', explode( "\n", $default_paths ) );
+
+		return $this->cloudfront_client->send_invalidation_request( $paths );
+	}
+}

--- a/includes/class-notglossy-cloudfront-path-validator.php
+++ b/includes/class-notglossy-cloudfront-path-validator.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Path Validator for CloudFront Cache Invalidator.
+ *
+ * Validates and sanitizes CloudFront invalidation paths according to
+ * AWS requirements (leading slash, max 3000 paths, duplicates removed).
+ *
+ * @since 1.2.0
+ * @package CloudFrontCacheInvalidator
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Path Validator class.
+ *
+ * @since 1.2.0
+ */
+class NotGlossy_CloudFront_Path_Validator {
+
+	/**
+	 * Validate and sanitize an array of invalidation paths for CloudFront API.
+	 *
+	 * Ensures paths meet CloudFront requirements:
+	 * - Must start with /
+	 * - Limited to 3000 paths per invalidation (AWS limit)
+	 * - Removes empty or invalid paths
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @param array $paths Array of paths to validate.
+	 * @return array|WP_Error Validated paths array or WP_Error if validation fails.
+	 */
+	public function sanitize_invalidation_paths_array( $paths ) {
+		if ( ! is_array( $paths ) || empty( $paths ) ) {
+			return new WP_Error( 'invalid_paths', 'Invalidation paths must be a non-empty array.' );
+		}
+
+		$validated_paths = array();
+
+		foreach ( $paths as $path ) {
+			// Ensure path is a string.
+			if ( ! is_string( $path ) ) {
+				continue;
+			}
+
+			// Trim whitespace.
+			$path = trim( $path );
+
+			// Skip empty paths.
+			if ( '' === $path ) {
+				continue;
+			}
+
+			// CloudFront requires paths to start with /.
+			if ( '/' !== substr( $path, 0, 1 ) ) {
+				$path = '/' . $path;
+			}
+
+			// Add to validated list.
+			$validated_paths[] = $path;
+		}
+
+		// Check if we have any valid paths after validation.
+		if ( empty( $validated_paths ) ) {
+			return new WP_Error( 'no_valid_paths', 'No valid invalidation paths provided.' );
+		}
+
+		// Remove duplicates.
+		$validated_paths = array_unique( $validated_paths );
+
+		// AWS CloudFront limit is 3000 paths per invalidation request.
+		if ( count( $validated_paths ) > 3000 ) {
+			return new WP_Error(
+				'too_many_paths',
+				sprintf(
+					'CloudFront allows a maximum of 3000 paths per invalidation request. You provided %d paths.',
+					count( $validated_paths )
+				)
+			);
+		}
+
+		return $validated_paths;
+	}
+}

--- a/includes/class-notglossy-cloudfront-settings-manager.php
+++ b/includes/class-notglossy-cloudfront-settings-manager.php
@@ -1,0 +1,660 @@
+<?php
+/**
+ * Settings Manager for CloudFront Cache Invalidator.
+ *
+ * Handles all WordPress settings functionality including registration,
+ * validation, sanitization, and admin form callbacks.
+ *
+ * @since 1.2.0
+ * @package CloudFrontCacheInvalidator
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Settings Manager class.
+ *
+ * Responsible for all WordPress Settings API integration, settings validation,
+ * and admin form field management.
+ *
+ * @since 1.2.0
+ */
+class NotGlossy_CloudFront_Settings_Manager {
+
+	/**
+	 * Credential manager instance.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @var NotGlossy_CloudFront_Credential_Manager|null
+	 */
+	private $credential_manager = null;
+
+	/**
+	 * Cached settings for tests/injection.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @var array|null
+	 */
+	private $current_settings = null;
+
+	/**
+	 * Settings group name.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @var string $settings_group WordPress settings group name.
+	 */
+	private $settings_group = 'cloudfront_cache_invalidator_settings';
+
+	/**
+	 * Settings option name.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @var string $settings_option WordPress settings option name.
+	 */
+	private $settings_option = 'cloudfront_cache_invalidator_options';
+
+	/**
+	 * Settings section ID.
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @var string $settings_section WordPress settings section ID.
+	 */
+	private $settings_section = 'cloudfront_cache_invalidator_section';
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 */
+	public function __construct() {
+		// Settings will be initialized when needed.
+	}
+
+	/**
+	 * Get settings option name.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return string Settings option name.
+	 */
+	public function get_settings_option() {
+		return $this->settings_option;
+	}
+
+	/**
+	 * Get settings group name.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return string Settings group name.
+	 */
+	public function get_settings_group() {
+		return $this->settings_group;
+	}
+
+	/**
+	 * Get settings section ID.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return string Settings section ID.
+	 */
+	public function get_settings_section() {
+		return $this->settings_section;
+	}
+
+	/**
+	 * Get all plugin settings.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return array Plugin settings.
+	 */
+	public function get_settings() {
+		if ( is_array( $this->current_settings ) ) {
+			return $this->current_settings;
+		}
+
+		$settings = get_option( $this->settings_option, array() );
+		if ( ! is_array( $settings ) ) {
+			$settings = array();
+		}
+		return $settings;
+	}
+
+	/**
+	 * Get a specific setting value.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @param string $key      Setting key.
+	 * @param mixed  $fallback Fallback value if setting doesn't exist.
+	 * @return mixed Setting value or fallback.
+	 */
+	public function get_setting( $key, $fallback = null ) {
+		$settings = $this->get_settings();
+
+		return array_key_exists( $key, $settings ) ? $settings[ $key ] : $fallback;
+	}
+
+	/**
+	 * Update a specific setting value.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @param string $key Setting key.
+	 * @param mixed  $value Setting value.
+	 * @return bool True on success, false on failure.
+	 */
+	public function update_setting( $key, $value ) {
+		$settings               = $this->get_settings();
+		$settings[ $key ]       = $value;
+		$this->current_settings = $settings;
+		return update_option( $this->settings_option, $settings );
+	}
+
+	/**
+	 * Inject settings (used by plugin to sync legacy property and tests).
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @param array $settings Settings array to use for subsequent reads.
+	 * @return void
+	 */
+	public function set_settings( array $settings ) {
+		$this->current_settings = $settings;
+	}
+
+	/**
+	 * Register plugin settings.
+	 *
+	 * Sets up the WordPress settings API fields, sections, and validations
+	 * for the plugin's configuration page.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return void
+	 */
+	public function register_settings() {
+		register_setting(
+			$this->settings_group,
+			$this->settings_option,
+			array( $this, 'validate_settings' )
+		);
+
+		add_settings_section(
+			$this->settings_section,
+			'CloudFront Cache Invalidator Settings',
+			array( $this, 'settings_section_callback' ),
+			'cloudfront-cache-invalidator'
+		);
+
+		add_settings_field(
+			'use_iam_role',
+			'Use IAM Role',
+			array( $this, 'use_iam_role_callback' ),
+			'cloudfront-cache-invalidator',
+			$this->settings_section
+		);
+
+		add_settings_field(
+			'aws_access_key',
+			'AWS Access Key',
+			array( $this, 'aws_access_key_callback' ),
+			'cloudfront-cache-invalidator',
+			$this->settings_section
+		);
+
+		add_settings_field(
+			'aws_secret_key',
+			'AWS Secret Key',
+			array( $this, 'aws_secret_key_callback' ),
+			'cloudfront-cache-invalidator',
+			$this->settings_section
+		);
+
+		add_settings_field(
+			'aws_region',
+			'AWS Region',
+			array( $this, 'aws_region_callback' ),
+			'cloudfront-cache-invalidator',
+			$this->settings_section
+		);
+
+		add_settings_field(
+			'distribution_id',
+			'CloudFront Distribution ID',
+			array( $this, 'distribution_id_callback' ),
+			'cloudfront-cache-invalidator',
+			$this->settings_section
+		);
+
+		add_settings_field(
+			'invalidation_paths',
+			'Default Invalidation Paths',
+			array( $this, 'invalidation_paths_callback' ),
+			'cloudfront-cache-invalidator',
+			$this->settings_section
+		);
+	}
+
+	/**
+	 * Add settings page to admin menu.
+	 *
+	 * Creates the admin menu item under Settings for plugin configuration.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return void
+	 */
+	public function add_settings_page() {
+		add_options_page(
+			'CloudFront Cache Invalidator',
+			'CloudFront Cache',
+			'manage_options',
+			'cloudfront-cache-invalidator',
+			array( $this, 'render_settings_page' )
+		);
+	}
+
+	/**
+	 * Settings section description.
+	 *
+	 * Outputs the HTML for the settings section description on the admin page.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return void
+	 */
+	public function settings_section_callback() {
+		echo '<p>Configure your AWS credentials and CloudFront distribution settings.</p>';
+		echo '<p>If your WordPress site is running on an EC2 instance or other AWS service, you can use IAM roles for secure, key-less authentication.</p>';
+	}
+
+	/**
+	 * IAM Role field callback.
+	 *
+	 * Renders the IAM role checkbox field for the settings page.
+	 * This enables using AWS IAM roles instead of access keys.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return void
+	 */
+	public function use_iam_role_callback() {
+		$value = $this->get_setting( 'use_iam_role', '0' );
+		echo '<input type="checkbox" id="use_iam_role" name="' . esc_attr( $this->settings_option ) . '[use_iam_role]" value="1" ' . checked( '1', $value, false ) . '/>';
+		echo '<label for="use_iam_role"> Use instance IAM role (recommended if your WordPress server is running on AWS)</label>';
+		echo '<p class="description">When enabled, AWS access keys below are optional and will only be used as a fallback.</p>';
+	}
+
+	/**
+	 * AWS Access Key field callback.
+	 *
+	 * Renders the AWS Access Key field for the settings page.
+	 * This field can be disabled when using IAM roles.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return void
+	 */
+	public function aws_access_key_callback() {
+		$disabled    = $this->get_setting( 'use_iam_role' ) === '1' ? 'disabled' : '';
+		$has_stored  = ! empty( $this->get_setting( 'credentials_stored' ) ) && ! empty( $this->get_setting( 'aws_access_key_enc' ) );
+		$placeholder = $has_stored ? '******** (stored)' : '';
+		echo '<input type="text" id="aws_access_key" name="' . esc_attr( $this->settings_option ) . '[aws_access_key]" value="" placeholder="' . esc_attr( $placeholder ) . '" class="regular-text" ' . esc_attr( $disabled ) . '/>';
+		echo '<p class="description">Optional when using IAM role. Leave blank to keep existing; enter a new key to replace.</p>';
+	}
+
+	/**
+	 * AWS Secret Key field callback.
+	 *
+	 * Renders the AWS Secret Key field for the settings page.
+	 * This field can be disabled when using IAM roles.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return void
+	 */
+	public function aws_secret_key_callback() {
+		$disabled    = $this->get_setting( 'use_iam_role' ) === '1' ? 'disabled' : '';
+		$has_stored  = ! empty( $this->get_setting( 'credentials_stored' ) ) && ! empty( $this->get_setting( 'aws_secret_key_enc' ) );
+		$placeholder = $has_stored ? '******** (stored)' : '';
+		echo '<input type="password" id="aws_secret_key" name="' . esc_attr( $this->settings_option ) . '[aws_secret_key]" value="" placeholder="' . esc_attr( $placeholder ) . '" class="regular-text" ' . esc_attr( $disabled ) . '/>';
+		echo '<p class="description">Optional when using IAM role. Leave blank to keep existing; enter a new secret to replace.</p>';
+	}
+
+	/**
+	 * AWS Region field callback.
+	 *
+	 * Renders the AWS Region field for the settings page.
+	 * Defaults to us-east-1 if not specified.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return void
+	 */
+	public function aws_region_callback() {
+		$value = $this->get_setting( 'aws_region', 'us-east-1' );
+		echo '<input type="text" id="aws_region" name="' . esc_attr( $this->settings_option ) . '[aws_region]" value="' . esc_attr( $value ) . '" class="regular-text" />';
+		echo '<p class="description">AWS region (e.g., us-east-1, eu-west-2, ap-southeast-1). Default: us-east-1</p>';
+	}
+
+	/**
+	 * Distribution ID field callback.
+	 *
+	 * Renders the CloudFront Distribution ID field for the settings page.
+	 * This is required for all invalidation requests.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return void
+	 */
+	public function distribution_id_callback() {
+		$value = $this->get_setting( 'distribution_id', '' );
+		echo '<input type="text" id="distribution_id" name="' . esc_attr( $this->settings_option ) . '[distribution_id]" value="' . esc_attr( $value ) . '" class="regular-text" />';
+		echo '<p class="description">CloudFront Distribution ID (13-14 uppercase characters, e.g., E1ABCDEFGHIJKL)</p>';
+	}
+
+	/**
+	 * Invalidation Paths field callback.
+	 *
+	 * Renders the Default Invalidation Paths field for the settings page.
+	 * These paths will be used for site-wide invalidations.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return void
+	 */
+	public function invalidation_paths_callback() {
+		$value = $this->get_setting( 'invalidation_paths', '/*' );
+		echo '<textarea id="invalidation_paths" name="' . esc_attr( $this->settings_option ) . '[invalidation_paths]" rows="3" class="large-text">' . esc_textarea( $value ) . '</textarea>';
+		echo '<p class="description">Enter paths to invalidate (one per line). Each path must start with /. Examples: /*, /blog/*, /images/logo.png</p>';
+	}
+
+	/**
+	 * Validate AWS region format.
+	 *
+	 * Validates that the AWS region follows the correct format pattern.
+	 * Examples: us-east-1, eu-west-2, ap-southeast-1
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @param string $region AWS region to validate.
+	 * @return string|WP_Error Validated region or WP_Error on failure.
+	 */
+	private function validate_aws_region( $region ) {
+		$region = trim( strtolower( $region ) );
+
+		// Allow empty region (will use default).
+		if ( '' === $region ) {
+			return $region;
+		}
+
+		// Validate region format: xx-xxxx-# or xxx-xxxx-#.
+		if ( ! preg_match( '/^[a-z]{2,3}-[a-z]+-\d+$/', $region ) ) {
+			return new WP_Error(
+				'invalid_aws_region',
+				__( 'Invalid AWS region format. Please use format like: us-east-1, eu-west-2, ap-southeast-1', 'cloudfront-cache-invalidator' )
+			);
+		}
+
+		return $region;
+	}
+
+	/**
+	 * Validate CloudFront Distribution ID format.
+	 *
+	 * Validates and normalizes the CloudFront Distribution ID.
+	 * Distribution IDs are 13-14 uppercase alphanumeric characters.
+	 * Examples: E1ABCDEFGHIJKL, E2XYZ123456789
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @param string $distribution_id Distribution ID to validate.
+	 * @return string|WP_Error Validated (uppercase) distribution ID or WP_Error on failure.
+	 */
+	private function validate_distribution_id( $distribution_id ) {
+		$distribution_id = trim( strtoupper( $distribution_id ) );
+
+		// Validate distribution ID format: 13-14 alphanumeric characters.
+		if ( ! preg_match( '/^[A-Z0-9]{13,14}$/', $distribution_id ) ) {
+			return new WP_Error(
+				'invalid_distribution_id',
+				__( 'Invalid CloudFront Distribution ID. Expected 13-14 uppercase alphanumeric characters (e.g., E1ABCDEFGHIJKL)', 'cloudfront-cache-invalidator' )
+			);
+		}
+
+		return $distribution_id;
+	}
+
+	/**
+	 * Validate invalidation paths format.
+	 *
+	 * Validates that each invalidation path starts with a forward slash.
+	 * CloudFront requires all paths to begin with /.
+	 * Examples: /*, /blog/*, /images/logo.png
+	 *
+	 * @since 1.2.0
+	 * @access private
+	 * @param string $paths Newline-separated invalidation paths.
+	 * @return string|WP_Error Validated paths or WP_Error on failure.
+	 */
+	private function validate_invalidation_paths( $paths ) {
+		// Split paths by newline and trim each.
+		$paths_array = array_map( 'trim', explode( "\n", $paths ) );
+
+		// Filter out empty lines.
+		$paths_array = array_filter(
+			$paths_array,
+			function ( $path ) {
+				return '' !== $path;
+			}
+		);
+
+		// Must have at least one path.
+		if ( empty( $paths_array ) ) {
+			return new WP_Error(
+				'empty_invalidation_paths',
+				__( 'At least one invalidation path is required.', 'cloudfront-cache-invalidator' )
+			);
+		}
+
+		// Validate each path starts with /.
+		foreach ( $paths_array as $path ) {
+			if ( '/' !== substr( $path, 0, 1 ) ) {
+				return new WP_Error(
+					'invalid_invalidation_path',
+					sprintf(
+						/* translators: %s: The invalid path */
+						__( 'Invalidation path "%s" must start with /. Example: /*, /blog/*, /images/', 'cloudfront-cache-invalidator' ),
+						esc_html( $path )
+					)
+				);
+			}
+		}
+
+		// Return validated paths joined by newline.
+		return implode( "\n", $paths_array );
+	}
+
+	/**
+	 * Validate settings.
+	 *
+	 * Sanitizes and validates user input from the settings form.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @param array $input The raw input from the settings form.
+	 * @return array Sanitized settings values.
+	 */
+	public function validate_settings( $input ) {
+		// Start with existing settings so we can preserve encrypted values when fields are left blank.
+		$new_input = $this->get_settings();
+
+		// IAM role checkbox.
+		$new_input['use_iam_role'] = isset( $input['use_iam_role'] ) ? '1' : '0';
+
+		// Enforce HTTPS for credential submission.
+		$is_ssl = is_ssl();
+
+		$submitted_access = isset( $input['aws_access_key'] ) ? trim( $input['aws_access_key'] ) : '';
+		$submitted_secret = isset( $input['aws_secret_key'] ) ? trim( $input['aws_secret_key'] ) : '';
+
+		if ( ! $is_ssl && ( '' !== $submitted_access || '' !== $submitted_secret ) ) {
+			add_settings_error( $this->settings_option, 'cloudfront_https_required', __( 'AWS credentials cannot be saved over an insecure (HTTP) connection. Please use HTTPS.', 'cloudfront-cache-invalidator' ), 'error' );
+			// Do not modify stored credentials if submitted over HTTP.
+		} else {
+			// Access key handling.
+			if ( '' !== $submitted_access ) {
+				$new_input['aws_access_key'] = sanitize_text_field( $submitted_access );
+			}
+
+			// Secret key handling.
+			if ( '' !== $submitted_secret ) {
+				$new_input['aws_secret_key'] = sanitize_text_field( $submitted_secret );
+			}
+		}
+
+		// Region validation.
+		if ( isset( $input['aws_region'] ) ) {
+			$region = sanitize_text_field( $input['aws_region'] );
+
+			$validated_region = $this->validate_aws_region( $region );
+			if ( is_wp_error( $validated_region ) ) {
+				add_settings_error(
+					$this->settings_option,
+					'invalid_aws_region',
+					$validated_region->get_error_message(),
+					'error'
+				);
+				// Keep existing or use default.
+				$new_input['aws_region'] = $this->get_setting( 'aws_region', 'us-east-1' );
+			} else {
+				$new_input['aws_region'] = $validated_region;
+			}
+		}
+
+		// Distribution ID validation.
+		if ( isset( $input['distribution_id'] ) ) {
+			$dist_id = sanitize_text_field( $input['distribution_id'] );
+
+			// Allow empty (user can clear the field).
+			if ( '' === $dist_id ) {
+				$new_input['distribution_id'] = '';
+			} else {
+				$validated_dist_id = $this->validate_distribution_id( $dist_id );
+				if ( is_wp_error( $validated_dist_id ) ) {
+					add_settings_error(
+						$this->settings_option,
+						'invalid_distribution_id',
+						$validated_dist_id->get_error_message(),
+						'error'
+					);
+					// Keep existing value.
+					$new_input['distribution_id'] = $this->get_setting( 'distribution_id', '' );
+				} else {
+					$new_input['distribution_id'] = $validated_dist_id;
+				}
+			}
+		}
+
+		// Invalidation paths validation.
+		if ( isset( $input['invalidation_paths'] ) ) {
+			$paths = sanitize_textarea_field( $input['invalidation_paths'] );
+
+			$validated_paths = $this->validate_invalidation_paths( $paths );
+			if ( is_wp_error( $validated_paths ) ) {
+				add_settings_error(
+					$this->settings_option,
+					'invalid_invalidation_paths',
+					$validated_paths->get_error_message(),
+					'error'
+				);
+				// Keep existing or use default.
+				$new_input['invalidation_paths'] = $this->get_setting( 'invalidation_paths', '/*' );
+			} else {
+				$new_input['invalidation_paths'] = $validated_paths;
+			}
+		}
+
+		return $new_input;
+	}
+
+	/**
+	 * Render the settings page.
+	 *
+	 * Outputs the HTML for the plugin's admin settings page,
+	 * including the settings form and manual invalidation button.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @return void
+	 */
+	public function render_settings_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html( __( 'You do not have sufficient permissions to access this page.', 'cloudfront-cache-invalidator' ) ) );
+		}
+		?>
+		<div class="wrap">
+			<h1>CloudFront Cache Invalidator</h1>
+
+			<?php if ( ! is_ssl() ) : ?>
+				<div class="notice notice-error">
+					<p><strong><?php esc_html_e( 'Warning:', 'cloudfront-cache-invalidator' ); ?></strong> <?php esc_html_e( 'You are not using HTTPS. AWS credentials will not be saved over HTTP. Please switch to HTTPS before entering access keys.', 'cloudfront-cache-invalidator' ); ?></p>
+				</div>
+			<?php endif; ?>
+
+			<div class="notice notice-info">
+				<p><strong>IAM Role Support:</strong> If your WordPress site is running on AWS (EC2, ECS, Elastic Beanstalk, etc.), you can use IAM roles for authentication instead of access keys. This is more secure and easier to manage.</p>
+				<p>To use this feature:</p>
+				<ol>
+					<li>Create an IAM role with CloudFront invalidation permissions</li>
+					<li>Attach the role to your EC2 instance or other AWS service</li>
+					<li>Check the "Use IAM Role" option below</li>
+				</ol>
+				<p>Example IAM policy for CloudFront invalidation:</p>
+				<pre>{
+	"Version": "2012-10-17",
+	"Statement": [
+	{
+		"Effect": "Allow",
+		"Action": [
+		"cloudfront:CreateInvalidation",
+		"cloudfront:GetInvalidation",
+		"cloudfront:ListInvalidations"
+		],
+		"Resource": "arn:aws:cloudfront::*:distribution/*"
+	}
+	]
+	}</pre>
+			</div>
+
+			<form method="post" action="options.php">
+				<?php
+				settings_fields( $this->settings_group );
+				do_settings_sections( 'cloudfront-cache-invalidator' );
+				submit_button();
+				?>
+			</form>
+			<hr>
+			<h2>Manual Invalidation</h2>
+			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+				<input type="hidden" name="action" value="cloudfront_invalidate_all">
+				<?php wp_nonce_field( 'manual_invalidation', 'cloudfront_invalidation_nonce' ); ?>
+				<p>
+					<input type="submit" name="cloudfront_invalidate_all" class="button button-primary" value="Invalidate All CloudFront Cache">
+				</p>
+			</form>
+		</div>
+		<?php
+	}
+}

--- a/includes/class-notglossy-cloudfront-settings-manager.php
+++ b/includes/class-notglossy-cloudfront-settings-manager.php
@@ -33,6 +33,18 @@ class NotGlossy_CloudFront_Settings_Manager {
 	private $credential_manager = null;
 
 	/**
+	 * Set the credential manager instance.
+	 *
+	 * @since 1.2.0
+	 * @access public
+	 * @param NotGlossy_CloudFront_Credential_Manager $credential_manager Credential manager instance.
+	 * @return void
+	 */
+	public function set_credential_manager( NotGlossy_CloudFront_Credential_Manager $credential_manager ) {
+		$this->credential_manager = $credential_manager;
+	}
+
+	/**
 	 * Cached settings for tests/injection.
 	 *
 	 * @since 1.2.0
@@ -512,16 +524,10 @@ class NotGlossy_CloudFront_Settings_Manager {
 		if ( ! $is_ssl && ( '' !== $submitted_access || '' !== $submitted_secret ) ) {
 			add_settings_error( $this->settings_option, 'cloudfront_https_required', __( 'AWS credentials cannot be saved over an insecure (HTTP) connection. Please use HTTPS.', 'cloudfront-cache-invalidator' ), 'error' );
 			// Do not modify stored credentials if submitted over HTTP.
-		} else {
-			// Access key handling.
-			if ( '' !== $submitted_access ) {
-				$new_input['aws_access_key'] = sanitize_text_field( $submitted_access );
-			}
-
-			// Secret key handling.
-			if ( '' !== $submitted_secret ) {
-				$new_input['aws_secret_key'] = sanitize_text_field( $submitted_secret );
-			}
+		} elseif ( null !== $this->credential_manager ) {
+			// Encrypt credentials via the credential manager — never store plaintext.
+			$credential_settings = $this->credential_manager->process_credential_submission( $input );
+			$new_input           = array_merge( $credential_settings, $new_input );
 		}
 
 		// Region validation.

--- a/tests/Integration/HookRegistrationTest.php
+++ b/tests/Integration/HookRegistrationTest.php
@@ -47,6 +47,12 @@ class HookRegistrationTest extends TestCase {
 
 		// Create plugin instance which registers hooks in constructor.
 		$this->plugin = new NotGlossy_CloudFront_Cache_Invalidator();
+
+		// Ensure the test helper can still set legacy $settings via reflection.
+		$reflection = new ReflectionClass( $this->plugin );
+		$property   = $reflection->getProperty( 'settings' );
+		$property->setAccessible( true );
+		$property->setValue( $this->plugin, array() );
 	}
 
 	/**

--- a/tests/Integration/HookRegistrationTest.php
+++ b/tests/Integration/HookRegistrationTest.php
@@ -51,7 +51,6 @@ class HookRegistrationTest extends TestCase {
 		// Ensure the test helper can still set legacy $settings via reflection.
 		$reflection = new ReflectionClass( $this->plugin );
 		$property   = $reflection->getProperty( 'settings' );
-		$property->setAccessible( true );
 		$property->setValue( $this->plugin, array() );
 	}
 

--- a/tests/Integration/SettingsValidationTest.php
+++ b/tests/Integration/SettingsValidationTest.php
@@ -216,11 +216,20 @@ class SettingsValidationTest extends TestCase {
 	}
 
 	private function seed_settings( array $settings ): void {
-		$reflection = new ReflectionClass( $this->plugin );
-		$property   = $reflection->getProperty( 'settings' );
-		// Note: setAccessible() is no longer needed in PHP 8.1+, as private properties
-		// are accessible via reflection by default.
-		$property->setValue( $this->plugin, $settings );
+		// Update plugin's settings property.
+		$plugin_reflection = new ReflectionClass( $this->plugin );
+		$plugin_property   = $plugin_reflection->getProperty( 'settings' );
+		$plugin_property->setValue( $this->plugin, $settings );
+
+		// Also update settings_manager's current_settings so credential processing sees them.
+		$settings_manager_property = $plugin_reflection->getProperty( 'settings_manager' );
+		$settings_manager_property->setAccessible( true );
+		$settings_manager = $settings_manager_property->getValue( $this->plugin );
+
+		$sm_reflection = new ReflectionClass( $settings_manager );
+		$sm_property   = $sm_reflection->getProperty( 'current_settings' );
+		$sm_property->setAccessible( true );
+		$sm_property->setValue( $settings_manager, $settings );
 	}
 
 	public function test_http_submission_preserves_existing_credentials() {

--- a/tests/Integration/SettingsValidationTest.php
+++ b/tests/Integration/SettingsValidationTest.php
@@ -223,12 +223,10 @@ class SettingsValidationTest extends TestCase {
 
 		// Also update settings_manager's current_settings so credential processing sees them.
 		$settings_manager_property = $plugin_reflection->getProperty( 'settings_manager' );
-		$settings_manager_property->setAccessible( true );
 		$settings_manager = $settings_manager_property->getValue( $this->plugin );
 
 		$sm_reflection = new ReflectionClass( $settings_manager );
 		$sm_property   = $sm_reflection->getProperty( 'current_settings' );
-		$sm_property->setAccessible( true );
 		$sm_property->setValue( $settings_manager, $settings );
 	}
 

--- a/tests/Unit/AwsSdkMockingTest.php
+++ b/tests/Unit/AwsSdkMockingTest.php
@@ -87,10 +87,22 @@ class AwsSdkMockingTest extends TestCase {
 	 * Ensure missing distribution ID returns WP_Error.
 	 */
 	public function test_send_invalidation_request_returns_error_when_distribution_missing(): void {
-		$reflection = new ReflectionClass( $this->plugin );
-		$property   = $reflection->getProperty( 'settings' );
-		$property->setAccessible( true );
-		$property->setValue( $this->plugin, array() );
+		// Update plugin's settings through reflection.
+		$plugin_reflection = new ReflectionClass( $this->plugin );
+		$plugin_property   = $plugin_reflection->getProperty( 'settings' );
+		$plugin_property->setAccessible( true );
+		$plugin_property->setValue( $this->plugin, array() );
+
+		// Also update settings_manager's current_settings so it doesn't use old values.
+		$settings_manager_reflection = new ReflectionClass( $this->plugin );
+		$settings_manager_property   = $settings_manager_reflection->getProperty( 'settings_manager' );
+		$settings_manager_property->setAccessible( true );
+		$settings_manager = $settings_manager_property->getValue( $this->plugin );
+
+		$sm_reflection = new ReflectionClass( $settings_manager );
+		$sm_property   = $sm_reflection->getProperty( 'current_settings' );
+		$sm_property->setAccessible( true );
+		$sm_property->setValue( $settings_manager, array() );
 
 		$result = $this->plugin->send_invalidation_request( array( '/*' ) );
 

--- a/tests/Unit/AwsSdkMockingTest.php
+++ b/tests/Unit/AwsSdkMockingTest.php
@@ -45,7 +45,6 @@ class AwsSdkMockingTest extends TestCase {
 		// Seed plugin settings via reflection.
 		$reflection = new ReflectionClass( $this->plugin );
 		$property   = $reflection->getProperty( 'settings' );
-		$property->setAccessible( true );
 		$property->setValue(
 			$this->plugin,
 			array(
@@ -90,18 +89,15 @@ class AwsSdkMockingTest extends TestCase {
 		// Update plugin's settings through reflection.
 		$plugin_reflection = new ReflectionClass( $this->plugin );
 		$plugin_property   = $plugin_reflection->getProperty( 'settings' );
-		$plugin_property->setAccessible( true );
 		$plugin_property->setValue( $this->plugin, array() );
 
 		// Also update settings_manager's current_settings so it doesn't use old values.
 		$settings_manager_reflection = new ReflectionClass( $this->plugin );
 		$settings_manager_property   = $settings_manager_reflection->getProperty( 'settings_manager' );
-		$settings_manager_property->setAccessible( true );
 		$settings_manager = $settings_manager_property->getValue( $this->plugin );
 
 		$sm_reflection = new ReflectionClass( $settings_manager );
 		$sm_property   = $sm_reflection->getProperty( 'current_settings' );
-		$sm_property->setAccessible( true );
 		$sm_property->setValue( $settings_manager, array() );
 
 		$result = $this->plugin->send_invalidation_request( array( '/*' ) );

--- a/tests/Unit/EncryptionTest.php
+++ b/tests/Unit/EncryptionTest.php
@@ -187,16 +187,16 @@ class EncryptionTest extends TestCase {
 
 		$data = json_decode( $encrypted, true );
 		$this->assertIsArray( $data, 'Encrypted output should be a valid JSON object' );
-		$this->assertArrayHasKey( 'iv', $data, 'Encrypted output should have an iv key' );
+		$this->assertArrayHasKey( 'nonce', $data, 'Encrypted output should have a nonce key' );
 		$this->assertArrayHasKey( 'value', $data, 'Encrypted output should have a value key' );
-		$this->assertNotEmpty( $data['iv'], 'IV should not be empty' );
+		$this->assertNotEmpty( $data['nonce'], 'Nonce should not be empty' );
 		$this->assertNotEmpty( $data['value'], 'Value should not be empty' );
 	}
 
 	/**
-	 * Test that IV is random and different each time.
+	 * Test that nonce is random and different each time.
 	 */
-	public function test_iv_is_random() {
+	public function test_nonce_is_random() {
 		$plaintext = 'test';
 
 		$encrypted1 = $this->call_private_method( $this->plugin, 'encrypt_value', array( $plaintext ) );
@@ -205,7 +205,7 @@ class EncryptionTest extends TestCase {
 		$data1 = json_decode( $encrypted1, true );
 		$data2 = json_decode( $encrypted2, true );
 
-		$this->assertNotEquals( $data1['iv'], $data2['iv'], 'IV should be different for each encryption' );
+		$this->assertNotEquals( $data1['nonce'], $data2['nonce'], 'Nonce should be different for each encryption' );
 	}
 
 	/**


### PR DESCRIPTION
During refactoring, it was discovered that:
- It was possible to store credentials unencrypted 
- When they were encrypted, they were stored without HMAC

This commit updates the code to be:
- refactored, with major functions isolated into their own classes (no auth sitting next to settings page rendering, etc)
- Moves from OpenSSL to sodium, since WordPress includes this as a polyfill if the extension is not installed
