### PR TITLE
Fix Encryption Key Derivation

### DIFF
--- a/includes/class-notglossy-cloudfront-credential-manager.php
+++ b/includes/class-notglossy-cloudfront-credential-manager.php
@@ -103,7 +103,12 @@ class NotGlossy_CloudFront_Credential_Manager {
 			$parts[] = wp_salt( 'auth' );
 		}
 
-		return hash( 'sha256', implode( '', $parts ), true );
+		return hash_hkdf(
+			'sha256',
+			implode( '|', $parts ),
+			SODIUM_CRYPTO_SECRETBOX_KEYBYTES,
+			'cloudfront-cache-invalidator-encryption'
+		);
 	}
 
 	/**


### PR DESCRIPTION
The current method:
`
$parts[] = AUTH_KEY;
$parts[] = SECURE_AUTH_KEY;
return hash( 'sha256', implode( '', $parts ), true );`

Means `['ab','cd']` returns the same result as `['a','bcd']`. Switching to HKDF + adding a delimiter when imploding the parts ensures less possibility of collisions occurring (now `ab|cd` vs `a|bcd`). 