### PR TITLE
Delegate hook registration; fix AWS client config

### DIFF
--- a/includes/class-notglossy-cloudfront-cache-invalidator.php
+++ b/includes/class-notglossy-cloudfront-cache-invalidator.php
@@ -116,34 +116,8 @@ class NotGlossy_CloudFront_Cache_Invalidator {
 	 * @return void
 	 */
 	public function register_hooks() {
-		// Content update hooks (delegate to invalidation manager).
-		add_action( 'save_post', array( $this, 'invalidate_on_post_update' ), 10, 3 );
-		add_action( 'deleted_post', array( $this, 'invalidate_on_post_delete' ) );
-
-		// Theme and customizer hooks.
-		add_action( 'switch_theme', array( $this, 'invalidate_all' ) );
-		add_action( 'customize_save_after', array( $this, 'invalidate_all' ) );
-		add_action( 'update_option_permalink_structure', array( $this, 'invalidate_all' ) );
-
-		// Plugin activation/deactivation hooks.
-		add_action( 'activated_plugin', array( $this, 'invalidate_all' ) );
-		add_action( 'deactivated_plugin', array( $this, 'invalidate_all' ) );
-
-		// Menu and widget hooks.
-		add_action( 'wp_update_nav_menu', array( $this, 'invalidate_all' ) );
-		add_action( 'update_option_sidebars_widgets', array( $this, 'invalidate_all' ) );
-
-		// Term hooks.
-		add_action( 'edited_term', array( $this, 'invalidate_on_term_update' ), 10, 3 );
-
-		// Admin hooks.
-		add_action( 'admin_init', array( $this, 'register_settings' ) );
-		add_action( 'admin_menu', array( $this, 'add_settings_page' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
-
-		// Manual invalidation hooks.
-		add_action( 'admin_post_cloudfront_invalidate_all', array( $this, 'handle_manual_invalidation' ) );
-		add_action( 'admin_notices', array( $this, 'display_invalidation_notices' ) );
+		$this->invalidation_manager->register_hooks();
+		$this->admin_interface->register_hooks();
 	}
 
 	/* -------------------------------------------------------------

--- a/includes/class-notglossy-cloudfront-client.php
+++ b/includes/class-notglossy-cloudfront-client.php
@@ -102,7 +102,7 @@ class NotGlossy_CloudFront_Client {
 		try {
 			// Set up AWS CloudFront client config.
 			$config = array(
-				'Version' => 'latest',
+				'version' => 'latest',
 				'region'  => $this->credential_manager->get_aws_region(),
 			);
 

--- a/tests/Integration/HookRegistrationTest.php
+++ b/tests/Integration/HookRegistrationTest.php
@@ -26,6 +26,27 @@ class HookRegistrationTest extends TestCase {
 	private $plugin;
 
 	/**
+	 * The invalidation manager instance.
+	 *
+	 * @var NotGlossy_CloudFront_Invalidation_Manager
+	 */
+	private $invalidation_manager;
+
+	/**
+	 * The admin interface instance.
+	 *
+	 * @var NotGlossy_CloudFront_Admin_Interface
+	 */
+	private $admin_interface;
+
+	/**
+	 * The settings manager instance.
+	 *
+	 * @var NotGlossy_CloudFront_Settings_Manager
+	 */
+	private $settings_manager;
+
+	/**
 	 * Test data fixtures.
 	 *
 	 * @var array
@@ -48,9 +69,19 @@ class HookRegistrationTest extends TestCase {
 		// Create plugin instance which registers hooks in constructor.
 		$this->plugin = new NotGlossy_CloudFront_Cache_Invalidator();
 
+		// Extract sub-class instances via reflection for hook assertions.
+		$reflection                 = new ReflectionClass( $this->plugin );
+		$inv_prop                   = $reflection->getProperty( 'invalidation_manager' );
+		$this->invalidation_manager = $inv_prop->getValue( $this->plugin );
+
+		$admin_prop           = $reflection->getProperty( 'admin_interface' );
+		$this->admin_interface = $admin_prop->getValue( $this->plugin );
+
+		$settings_prop         = $reflection->getProperty( 'settings_manager' );
+		$this->settings_manager = $settings_prop->getValue( $this->plugin );
+
 		// Ensure the test helper can still set legacy $settings via reflection.
-		$reflection = new ReflectionClass( $this->plugin );
-		$property   = $reflection->getProperty( 'settings' );
+		$property = $reflection->getProperty( 'settings' );
 		$property->setValue( $this->plugin, array() );
 	}
 
@@ -67,7 +98,7 @@ class HookRegistrationTest extends TestCase {
 	 */
 	public function test_save_post_hook_is_registered() {
 		$this->assertTrue(
-			has_action( 'save_post', array( $this->plugin, 'invalidate_on_post_update' ) ) !== false,
+			has_action( 'save_post', array( $this->invalidation_manager, 'invalidate_on_post_update' ) ) !== false,
 			'save_post hook should be registered with invalidate_on_post_update callback'
 		);
 	}
@@ -76,7 +107,7 @@ class HookRegistrationTest extends TestCase {
 	 * Test that save_post hook has correct priority.
 	 */
 	public function test_save_post_hook_has_correct_priority() {
-		$priority = has_action( 'save_post', array( $this->plugin, 'invalidate_on_post_update' ) );
+		$priority = has_action( 'save_post', array( $this->invalidation_manager, 'invalidate_on_post_update' ) );
 		$this->assertEquals(
 			10,
 			$priority,
@@ -89,7 +120,7 @@ class HookRegistrationTest extends TestCase {
 	 */
 	public function test_deleted_post_hook_is_registered() {
 		$this->assertTrue(
-			has_action( 'deleted_post', array( $this->plugin, 'invalidate_on_post_delete' ) ) !== false,
+			has_action( 'deleted_post', array( $this->invalidation_manager, 'invalidate_on_post_delete' ) ) !== false,
 			'deleted_post hook should be registered with invalidate_on_post_delete callback'
 		);
 	}
@@ -99,7 +130,7 @@ class HookRegistrationTest extends TestCase {
 	 */
 	public function test_switch_theme_hook_is_registered() {
 		$this->assertTrue(
-			has_action( 'switch_theme', array( $this->plugin, 'invalidate_all' ) ) !== false,
+			has_action( 'switch_theme', array( $this->invalidation_manager, 'invalidate_all' ) ) !== false,
 			'switch_theme hook should be registered with invalidate_all callback'
 		);
 	}
@@ -109,7 +140,7 @@ class HookRegistrationTest extends TestCase {
 	 */
 	public function test_customize_save_after_hook_is_registered() {
 		$this->assertTrue(
-			has_action( 'customize_save_after', array( $this->plugin, 'invalidate_all' ) ) !== false,
+			has_action( 'customize_save_after', array( $this->invalidation_manager, 'invalidate_all' ) ) !== false,
 			'customize_save_after hook should be registered with invalidate_all callback'
 		);
 	}
@@ -119,7 +150,7 @@ class HookRegistrationTest extends TestCase {
 	 */
 	public function test_wp_update_nav_menu_hook_is_registered() {
 		$this->assertTrue(
-			has_action( 'wp_update_nav_menu', array( $this->plugin, 'invalidate_all' ) ) !== false,
+			has_action( 'wp_update_nav_menu', array( $this->invalidation_manager, 'invalidate_all' ) ) !== false,
 			'wp_update_nav_menu hook should be registered with invalidate_all callback'
 		);
 	}
@@ -129,7 +160,7 @@ class HookRegistrationTest extends TestCase {
 	 */
 	public function test_edited_term_hook_is_registered() {
 		$this->assertTrue(
-			has_action( 'edited_term', array( $this->plugin, 'invalidate_on_term_update' ) ) !== false,
+			has_action( 'edited_term', array( $this->invalidation_manager, 'invalidate_on_term_update' ) ) !== false,
 			'edited_term hook should be registered with invalidate_on_term_update callback'
 		);
 	}
@@ -138,7 +169,7 @@ class HookRegistrationTest extends TestCase {
 	 * Test that edited_term hook has correct priority.
 	 */
 	public function test_edited_term_hook_has_correct_priority() {
-		$priority = has_action( 'edited_term', array( $this->plugin, 'invalidate_on_term_update' ) );
+		$priority = has_action( 'edited_term', array( $this->invalidation_manager, 'invalidate_on_term_update' ) );
 		$this->assertEquals(
 			10,
 			$priority,
@@ -151,17 +182,17 @@ class HookRegistrationTest extends TestCase {
 	 */
 	public function test_admin_hooks_are_registered() {
 		$this->assertTrue(
-			has_action( 'admin_init', array( $this->plugin, 'register_settings' ) ) !== false,
+			has_action( 'admin_init', array( $this->settings_manager, 'register_settings' ) ) !== false,
 			'admin_init hook should be registered with register_settings callback'
 		);
 
 		$this->assertTrue(
-			has_action( 'admin_menu', array( $this->plugin, 'add_settings_page' ) ) !== false,
+			has_action( 'admin_menu', array( $this->settings_manager, 'add_settings_page' ) ) !== false,
 			'admin_menu hook should be registered with add_settings_page callback'
 		);
 
 		$this->assertTrue(
-			has_action( 'admin_enqueue_scripts', array( $this->plugin, 'enqueue_admin_scripts' ) ) !== false,
+			has_action( 'admin_enqueue_scripts', array( $this->admin_interface, 'enqueue_admin_scripts' ) ) !== false,
 			'admin_enqueue_scripts hook should be registered with enqueue_admin_scripts callback'
 		);
 	}
@@ -171,12 +202,12 @@ class HookRegistrationTest extends TestCase {
 	 */
 	public function test_manual_invalidation_hooks_are_registered() {
 		$this->assertTrue(
-			has_action( 'admin_post_cloudfront_invalidate_all', array( $this->plugin, 'handle_manual_invalidation' ) ) !== false,
+			has_action( 'admin_post_cloudfront_invalidate_all', array( $this->admin_interface, 'handle_manual_invalidation' ) ) !== false,
 			'admin_post_cloudfront_invalidate_all hook should be registered'
 		);
 
 		$this->assertTrue(
-			has_action( 'admin_notices', array( $this->plugin, 'display_invalidation_notices' ) ) !== false,
+			has_action( 'admin_notices', array( $this->admin_interface, 'display_invalidation_notices' ) ) !== false,
 			'admin_notices hook should be registered'
 		);
 	}


### PR DESCRIPTION
After splitting the codebase into separate classes, some hook registration code was duplicated.

- Moved hook registration out of NotGlossy_CloudFront_Cache_Invalidator and delegated to the invalidation_manager and admin_interface components. 
- Also updated AWS SDK client config key from 'Version' to 'version'. 