### PR TITLE
Fix fatal errors when WordPress object caching (APCu) is active

### DIFF
--- a/cloudfront-cache-invalidator.php
+++ b/cloudfront-cache-invalidator.php
@@ -29,6 +29,21 @@ if ( ! defined( 'NOTGLOSSY_CLOUDFRONT_CACHE_INVALIDATOR_VERSION' ) ) {
 	define( 'NOTGLOSSY_CLOUDFRONT_CACHE_INVALIDATOR_VERSION', '1.2.0' );
 }
 
+/**
+ * Display admin notice when AWS SDK is missing.
+ *
+ * Defined as a named function instead of a closure to avoid serialization
+ * fatal errors when a persistent object cache (e.g. APCu) is active.
+ *
+ * @since 1.2.1
+ */
+function notglossy_cloudfront_sdk_missing_notice() {
+	echo '<div class="notice notice-error"><p>';
+	echo '<strong>' . esc_html__( 'CloudFront Cache Invalidator Error:', 'cloudfront-cache-invalidator' ) . '</strong> ';
+	echo esc_html__( 'AWS SDK for PHP is not installed. Please run "composer install" in the plugin directory to install dependencies.', 'cloudfront-cache-invalidator' );
+	echo '</p></div>';
+}
+
 // Include AWS SDK via Composer autoloader only if not already loaded by another plugin.
 $autoload_path = plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 if ( ! class_exists( 'Aws\CloudFront\CloudFrontClient' ) ) {
@@ -36,15 +51,7 @@ if ( ! class_exists( 'Aws\CloudFront\CloudFrontClient' ) ) {
 		require $autoload_path;
 	} else {
 		// Show admin notice if AWS SDK is missing and autoload cannot be found.
-		add_action(
-			'admin_notices',
-			function () {
-				echo '<div class="notice notice-error"><p>';
-				echo '<strong>' . esc_html__( 'CloudFront Cache Invalidator Error:', 'cloudfront-cache-invalidator' ) . '</strong> ';
-				echo esc_html__( 'AWS SDK for PHP is not installed. Please run "composer install" in the plugin directory to install dependencies.', 'cloudfront-cache-invalidator' );
-				echo '</p></div>';
-			}
-		);
+		add_action( 'admin_notices', 'notglossy_cloudfront_sdk_missing_notice' );
 	}
 }
 

--- a/includes/class-notglossy-cloudfront-client.php
+++ b/includes/class-notglossy-cloudfront-client.php
@@ -142,7 +142,7 @@ class NotGlossy_CloudFront_Client {
 
 			return $result;
 
-		} catch ( Exception $e ) {
+		} catch ( \Throwable $e ) {
 			do_action( 'notglossy_cloudfront_invalidation_error', $e );
 			return new WP_Error( 'invalidation_failed', $e->getMessage() );
 		}

--- a/includes/class-notglossy-cloudfront-invalidation-manager.php
+++ b/includes/class-notglossy-cloudfront-invalidation-manager.php
@@ -116,7 +116,7 @@ class NotGlossy_CloudFront_Invalidation_Manager {
 		$paths = array( $path, $path . '*' );
 
 		// If it's a front page or posts page, also invalidate root.
-		if ( 'page' === $post->post_type && ( get_option( 'page_on_front' ) === $post_id || get_option( 'page_for_posts' ) === $post_id ) ) {
+		if ( 'page' === $post->post_type && ( get_option( 'page_on_front' ) == $post_id || get_option( 'page_for_posts' ) == $post_id ) ) {
 			$paths[] = '/';
 			$paths[] = '/*';
 		}

--- a/includes/class-notglossy-cloudfront-invalidation-manager.php
+++ b/includes/class-notglossy-cloudfront-invalidation-manager.php
@@ -116,7 +116,7 @@ class NotGlossy_CloudFront_Invalidation_Manager {
 		$paths = array( $path, $path . '*' );
 
 		// If it's a front page or posts page, also invalidate root.
-		if ( 'page' === $post->post_type && ( get_option( 'page_on_front' ) == $post_id || get_option( 'page_for_posts' ) == $post_id ) ) {
+		if ( 'page' === $post->post_type && ( (int) get_option( 'page_on_front' ) === $post_id || (int) get_option( 'page_for_posts' ) === $post_id ) ) {
 			$paths[] = '/';
 			$paths[] = '/*';
 		}


### PR DESCRIPTION
Three issues caused crashes when a persistent object cache like APCu
is active and a page/post is modified:

1. catch (Exception) missed PHP Error/TypeError thrown by the AWS SDK
   when cached data has unexpected types after serialization round-trips.
   Changed to catch (\Throwable) to handle all throwable types.

2. Anonymous closure in admin_notices hook cannot be serialized by
   persistent object cache backends. Replaced with a named function.

3. Strict type comparison (===) between get_option() string return
   and integer $post_id meant front page root path invalidation
   never triggered. Changed to loose comparison (==).

https://claude.ai/code/session_017EGdpNBjypSJSsPJTeajhb